### PR TITLE
Fix a error that occurs when creating an instance of value type without parameters

### DIFF
--- a/Jurassic/Library/ClrWrapper/ClrStaticTypeWrapper.cs
+++ b/Jurassic/Library/ClrWrapper/ClrStaticTypeWrapper.cs
@@ -132,9 +132,19 @@ namespace Jurassic.Library
         /// <returns> The object that was created. </returns>
         public override ObjectInstance ConstructLateBound(params object[] argumentValues)
         {
-            if (this.constructBinder == null)
-                throw new JavaScriptException(this.Engine, "TypeError", string.Format("The type '{0}' has no public constructors", this.WrappedType));
-            var result = this.constructBinder.Call(this.Engine, this, argumentValues);
+            object result;
+
+            if (argumentValues.Length == 0 && this.WrappedType.IsValueType)
+            {
+                result = Activator.CreateInstance(this.WrappedType);
+            }
+            else
+            {
+                if (this.constructBinder == null)
+                    throw new JavaScriptException(this.Engine, "TypeError", string.Format("The type '{0}' has no public constructors", this.WrappedType));
+                result = this.constructBinder.Call(this.Engine, this, argumentValues);
+            }
+
             if (result is ObjectInstance)
                 return (ObjectInstance)result;
             return new ClrInstanceWrapper(this.Engine, result);

--- a/Unit Tests/Core/ScriptEngineTests.cs
+++ b/Unit Tests/Core/ScriptEngineTests.cs
@@ -382,6 +382,10 @@ namespace UnitTests
             engine.Execute("instance2 = new TestStruct(instance)");
             Assert.AreEqual(17, engine.Evaluate("instance2.Value"));
 
+            // Constructor without parameters.
+            engine.Execute("var instance3 = new TestStruct()");
+            Assert.AreEqual(0, engine.Evaluate("instance3.Value"));
+
             // Try dates.
             engine.SetGlobalValue("DateTime", typeof(DateTime));
             engine.Execute("date = new DateTime(2011, 3, 9, 7, 49, 0)");


### PR DESCRIPTION
When creating an instance of value type without parameters the following error occurs:

	No overload for method '.ctor' takes 0 arguments