### PR TITLE
Switch assembly on the .NET Framework 3.5 Client Profile

### DIFF
--- a/Jurassic/Jurassic.csproj
+++ b/Jurassic/Jurassic.csproj
@@ -20,7 +20,7 @@
     </SccAuxPath>
     <SccProvider>
     </SccProvider>
-    <TargetFrameworkProfile />
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Because Jurassic does not use features of .NET 3.5 Full Framework, then it is better to switch on .NET 3.5 Client Profile. This will simplify the deployment of Jurassic on desktop.

In addition, .NET 3.5 Client Profile does not contain an `System.Web` assembly, that in the future may contribute to porting Jurassic on .NET Core.