### PR TITLE
Allow to limit the maximum recursion depth for user-defined functions

### DIFF
--- a/Jurassic/Core/RecursionDepthOverflowException.cs
+++ b/Jurassic/Core/RecursionDepthOverflowException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Jurassic
+{
+    /// <summary>
+    /// The exception that is thrown when the allowed recursion depth for user-defined functions
+    /// of a script engine has been exceeded.
+    /// </summary>
+    public class RecursionDepthOverflowException : Exception
+    {
+        //     INITIALIZATION
+        //_________________________________________________________________________________________
+
+        /// <summary>
+        /// Creates a new RecursionDepthOverflowException instance.
+        /// </summary>
+        public RecursionDepthOverflowException()
+            : base("The allowed recursion depth of the script engine has been exceeded.")
+        {
+        }
+    }
+}

--- a/Jurassic/Core/ScriptEngine.cs
+++ b/Jurassic/Core/ScriptEngine.cs
@@ -216,6 +216,9 @@ namespace Jurassic
             // Deserialize the ForceStrictMode flag.
             this.ForceStrictMode = info.GetBoolean("forceStrictMode");
 
+            // Deserialize the RecursionDepthLimit flag.
+            this.RecursionDepthLimit = info.GetInt32("recursionDepthLimit");
+
             // Deserialize the built-in objects.
             this.globalObject = (GlobalObject)info.GetValue("globalObject", typeof(GlobalObject));
             this.arrayConstructor = (ArrayConstructor)info.GetValue("arrayConstructor", typeof(ArrayConstructor));
@@ -273,6 +276,9 @@ namespace Jurassic
 
             // Serialize the ForceStrictMode flag.
             info.AddValue("forceStrictMode", this.ForceStrictMode);
+
+            // Serialize the RecursionDepthLimit flag.
+            info.AddValue("recursionDepthLimit", this.RecursionDepthLimit);
 
             // Serialize the built-in objects.
             info.AddValue("globalObject", this.globalObject);
@@ -363,6 +369,19 @@ namespace Jurassic
             get;
             set;
         }
+
+        /// <summary>
+        /// Get or sets a value that indicates the maximum recursion depth of user-defined functions that
+        /// is allowed by this script engine. A negative number means that unlimited recursion is allowed.
+        /// When a user-defined function exceeds the recursion depth limit, a
+        /// <see cref="RecursionDepthOverflowException"/> will be thrown.
+        /// The default value is <c>-1</c> which allows unlimited recursion.
+        /// </summary>
+        public int RecursionDepthLimit
+        {
+            get;
+            set;
+        } = -1;
 
 #if !SILVERLIGHT
 

--- a/Jurassic/Jurassic.csproj
+++ b/Jurassic/Jurassic.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Core\CompatibilityMode.cs" />
     <Compile Include="Core\ConcatenatedString.cs" />
     <Compile Include="Core\CompiledScript.cs" />
+    <Compile Include="Core\RecursionDepthOverflowException.cs" />
     <Compile Include="Core\Serialization.cs" />
     <Compile Include="Core\StringHelpers.cs" />
     <Compile Include="Core\NumberFormatter.cs" />


### PR DESCRIPTION
Hi,

Jint has an option to limit the recursion depth of javascript functions. This allows to prevent against StackOverflowExceptions (which cannot be catched by default and will terminate the process), e.g. with a JS code like the following:
```javascript
var myarr = new Array(10000);
for (var i = 0; i < myarr.length; i++) {
    myarr[i] = function (i) {
        myarr[i + 1](i + 1);
    }
}

myarr[0](0);
```

Would it be possible to add such an option to Jurassic, e.g. like in this pull request? (I think the limit only needs to applied to instances of `UserDefinedFunction`).

Thanks!