### PR TITLE
Allow to transform script line numbers when formatting a stack trace

### DIFF
--- a/Jurassic/Core/ScriptEngine.cs
+++ b/Jurassic/Core/ScriptEngine.cs
@@ -1266,7 +1266,8 @@ namespace Jurassic
                 Path = path,
                 Function = function
             };
-            StackFrameTransform?.Invoke(ctx);
+            if (StackFrameTransform != null)
+                StackFrameTransform(ctx);
 
             result.AppendLine();
             result.Append("    ");

--- a/Jurassic/Core/ScriptEngine.cs
+++ b/Jurassic/Core/ScriptEngine.cs
@@ -1269,6 +1269,10 @@ namespace Jurassic
             if (StackFrameTransform != null)
                 StackFrameTransform(ctx);
 
+            // Check if we need to hide the current stack frame.
+            if (!ctx.ShowStackFrame)
+                return;
+
             result.AppendLine();
             result.Append("    ");
             result.Append("at ");

--- a/Jurassic/Core/ScriptEngine.cs
+++ b/Jurassic/Core/ScriptEngine.cs
@@ -1269,8 +1269,8 @@ namespace Jurassic
             if (StackFrameTransform != null)
                 StackFrameTransform(ctx);
 
-            // Check if we need to hide the current stack frame.
-            if (!ctx.ShowStackFrame)
+            // Check if we need to suppress the current stack frame.
+            if (ctx.SuppressStackFrame)
                 return;
 
             result.AppendLine();

--- a/Jurassic/Core/ScriptEngine.cs
+++ b/Jurassic/Core/ScriptEngine.cs
@@ -244,6 +244,25 @@ namespace Jurassic
         }
 
         /// <summary>
+        /// Represents a method that transforms a line number when formatting the stack trace.
+        /// </summary>
+        /// <param name="line">The line number which is to be transformed. Set this to <c>0</c>
+        /// if the resulting line number is unknown.</param>
+        public delegate void LineNumberTransformDelegate(ref int line);
+
+        /// <summary>
+        /// Gets or sets a delegate that transforms a script line number when
+        /// formatting the stack trace for <see cref="ErrorInstance.Stack"/>.
+        /// This can be useful if you are using a source map to map generated lines
+        /// to source lines and the stack trace should contain the source line numbers.
+        /// </summary>
+        public LineNumberTransformDelegate LineNumberTransform
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// The instance prototype of the Function object (i.e. Function.InstancePrototype).
         /// </summary>
         /// <remarks>
@@ -1241,6 +1260,10 @@ namespace Jurassic
         /// <param name="line"> The line number of the statement. </param>
         private void AppendStackFrame(System.Text.StringBuilder result, string path, string function, int line)
         {
+            // Check if we need to transform the line number.
+            if (line > 0 && LineNumberTransform != null)
+                LineNumberTransform(ref line);
+
             result.AppendLine();
             result.Append("    ");
             result.Append("at ");

--- a/Jurassic/Core/StackFrameTransformContext.cs
+++ b/Jurassic/Core/StackFrameTransformContext.cs
@@ -7,10 +7,23 @@
     public class StackFrameTransformContext
     {
         /// <summary>
+        /// Gets or sets a value that indicates if the stack frame represented by
+        /// this <see cref="StackFrameTransformContext"/> should actually be shown in the
+        /// stack trace.
+        /// The default value is <c>true</c>.
+        /// </summary>
+        public bool ShowStackFrame
+        {
+            get;
+            set;
+        } = true;
+
+        /// <summary>
         /// Gets or sets the line number. A value of <c>0</c> means the line number
         /// is unknown.
         /// </summary>
-        public int Line {
+        public int Line
+        {
             get;
             set;
         }

--- a/Jurassic/Core/StackFrameTransformContext.cs
+++ b/Jurassic/Core/StackFrameTransformContext.cs
@@ -8,15 +8,15 @@
     {
         /// <summary>
         /// Gets or sets a value that indicates if the stack frame represented by
-        /// this <see cref="StackFrameTransformContext"/> should actually be shown in the
-        /// stack trace.
-        /// The default value is <c>true</c>.
+        /// this <see cref="StackFrameTransformContext"/> should be suppressed, so that
+        /// it is not displayed in the stack trace.
+        /// The default value is <c>false</c>.
         /// </summary>
-        public bool ShowStackFrame
+        public bool SuppressStackFrame
         {
             get;
             set;
-        } = true;
+        }
 
         /// <summary>
         /// Gets or sets the line number. A value of <c>0</c> means the line number

--- a/Jurassic/Core/StackFrameTransformContext.cs
+++ b/Jurassic/Core/StackFrameTransformContext.cs
@@ -1,0 +1,37 @@
+﻿namespace Jurassic
+{
+    /// <summary>
+    /// Contains stack frame properties which can be transformed when formatting the
+    /// stack trace.
+    /// </summary>
+    public class StackFrameTransformContext
+    {
+        /// <summary>
+        /// Gets or sets the line number. A value of <c>0</c> means the line number
+        /// is unknown.
+        /// </summary>
+        public int Line {
+            get;
+            set;
+        }
+        
+        /// <summary>
+        /// Gets or sets the path of the javascript script file. A value of
+        /// <c>null</c> means that the path is unknown.
+        /// </summary>
+        public string Path
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the function. A value of <c>null</c> or
+        /// the empty string (<c>""</c>) means that the path is unknown.
+        public string Function
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/Jurassic/Jurassic.csproj
+++ b/Jurassic/Jurassic.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Core\CompatibilityMode.cs" />
     <Compile Include="Core\ConcatenatedString.cs" />
     <Compile Include="Core\CompiledScript.cs" />
+    <Compile Include="Core\StackFrameTransformContext.cs" />
     <Compile Include="Core\StringHelpers.cs" />
     <Compile Include="Core\NumberFormatter.cs" />
     <Compile Include="Core\NumberParser.cs" />


### PR DESCRIPTION
Hi,
when an `ErrorInstance` object thrown, its `Stack` property contains a stack trace with line numbers. Sometimes the JavaScript code to be executed is generated by a transpiler (e.g. TypeScript) which produces a source map, mapping the generated line and column numbers to source line and column numbers.

In our case, we are using TypeScript which produces JavaScript code and a source map, and if an Error object is thrown in JS, we would like to show the user a stack trace where the line numbers are transformed to the source line numbers using the source map. It think this could be done by setting a delegate in the ScriptEngine that allows to transform line numbers when formatting the Stack Trace for the `ErrorInstance`. Do you think this can be added to Jurassic? (Though I do not know if the Delegate type, `LineNumberTransformDelegate`, should be declared in its own file.)

Thanks!