### PR TITLE
Retain the original object on the stack for producing the error message.

### DIFF
--- a/Jurassic/Compiler/Expressions/BinaryExpression.cs
+++ b/Jurassic/Compiler/Expressions/BinaryExpression.cs
@@ -714,8 +714,8 @@ namespace Jurassic.Compiler
             EmitConversion.ToAny(generator, this.Right.ResultType);
 
             // Check the right-hand side is a function - if not, throw an exception.
-            generator.IsInstance(typeof(Library.FunctionInstance));
             generator.Duplicate();
+            generator.IsInstance(typeof(Library.FunctionInstance));
             var endOfTypeCheck = generator.CreateLabel();
             generator.BranchIfNotNull(endOfTypeCheck);
 


### PR DESCRIPTION
Fixes #59