### PR TITLE
Retain the original object on the stack for producing the error message.

### DIFF
--- a/Jurassic/Compiler/Expressions/BinaryExpression.cs
+++ b/Jurassic/Compiler/Expressions/BinaryExpression.cs
@@ -771,8 +771,8 @@ namespace Jurassic.Compiler
             EmitConversion.ToAny(generator, this.Right.ResultType);
 
             // Check the right-hand side is a javascript object - if not, throw an exception.
-            generator.IsInstance(typeof(Library.ObjectInstance));
             generator.Duplicate();
+            generator.IsInstance(typeof(Library.ObjectInstance));
             var endOfTypeCheck = generator.CreateLabel();
             generator.BranchIfNotNull(endOfTypeCheck);
 

--- a/Jurassic/Compiler/Expressions/NewExpression.cs
+++ b/Jurassic/Compiler/Expressions/NewExpression.cs
@@ -70,8 +70,8 @@ namespace Jurassic.Compiler
             }
 
             // Check the object really is a function - if not, throw an exception.
-            generator.IsInstance(typeof(Library.FunctionInstance));
             generator.Duplicate();
+            generator.IsInstance(typeof(Library.FunctionInstance));
             var endOfTypeCheck = generator.CreateLabel();
             generator.BranchIfNotNull(endOfTypeCheck);
 

--- a/Unit Tests/Compiler/ExpressionTests.cs
+++ b/Unit Tests/Compiler/ExpressionTests.cs
@@ -1076,6 +1076,7 @@ namespace UnitTests
             Assert.AreEqual("five", Evaluate("new String('five').toString()"));
             Assert.AreEqual("5", Evaluate("new Number(5).toString()"));
             Assert.AreEqual("TypeError", EvaluateExceptionType("new (String('five'))"));
+            Assert.AreEqual("TypeError: The new operator requires a function, found a 'string' instead", EvaluateExceptionMessage("new (String('five'))"));
 
             // Precedence tests.
             Assert.AreEqual("[object Object]", Evaluate("x = {}; x.f = function() { }; (new x.f()).toString()"));
@@ -1157,6 +1158,7 @@ namespace UnitTests
             Assert.AreEqual(true, Evaluate("'toString' in new String()"));
             Assert.AreEqual(true, Evaluate("var x = 'atan2', y = Math; x in y"));
             Assert.AreEqual("TypeError", EvaluateExceptionType("'toString' in 5"));
+            Assert.AreEqual("TypeError: The in operator expected an object, but found 'number' instead", EvaluateExceptionMessage("'toString' in 5"));
 
             // Check order of evaluation - should be left to right.
             Assert.AreEqual("x", Evaluate(@"


### PR DESCRIPTION
Fixes #61