### PR TITLE
Improve conversion from .NET to JS date

### DIFF
--- a/Jurassic/Library/Date/DateInstance.cs
+++ b/Jurassic/Library/Date/DateInstance.cs
@@ -1111,6 +1111,7 @@ namespace Jurassic.Library
         {
             if (dateTime == InvalidDate)
                 return double.NaN;
+            // Once we target .NET 4.6, use DateTimeOffset.ToUnixTimeMilliseconds().
             return dateTime.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond -
                 new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks / TimeSpan.TicksPerMillisecond;
         }

--- a/Jurassic/Library/Date/DateInstance.cs
+++ b/Jurassic/Library/Date/DateInstance.cs
@@ -1111,7 +1111,8 @@ namespace Jurassic.Library
         {
             if (dateTime == InvalidDate)
                 return double.NaN;
-            return Math.Round(dateTime.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds);
+            return dateTime.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond -
+                new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks / TimeSpan.TicksPerMillisecond;
         }
 
         /// <summary>

--- a/Unit Tests/Library/DateTests.cs
+++ b/Unit Tests/Library/DateTests.cs
@@ -705,7 +705,7 @@ namespace UnitTests
             jurassicScriptEngine.SetGlobalValue("specialDate1", specialNowDate1);
 
             Assert.AreEqual(Evaluate("specialDate1.toUTCString()"), Evaluate("new Date(specialDate1.getTime()).toUTCString()"));
-            Assert.AreEqual(1451649599999, Evaluate("specialDate1.getTime()"));
+            Assert.AreEqual(1451649599999d, Convert.ToDouble(Evaluate("specialDate1.getTime()")));
 
             // Simulate "new Date" at 1969-12-31T23:59:59.9999999Z.
             DateInstance specialNowDate2 = new DateInstance(jurassicScriptEngine.Date.InstancePrototype);
@@ -719,7 +719,9 @@ namespace UnitTests
 
         private static object ToJSDate(DateTime dateTime)
         {
-            double result = Math.Round(dateTime.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds);
+            // Once we target .NET 4.6, use DateTimeOffset.ToUnixTimeMilliseconds().
+            double result = dateTime.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond -
+                new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks / TimeSpan.TicksPerMillisecond;
             if ((double)(int)result == result)
                 return (int)result;
             return result;

--- a/Unit Tests/Library/DateTests.cs
+++ b/Unit Tests/Library/DateTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Globalization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Jurassic.Library;
-using System.Globalization;
 
 namespace UnitTests
 {

--- a/Unit Tests/Library/DateTests.cs
+++ b/Unit Tests/Library/DateTests.cs
@@ -706,9 +706,9 @@ namespace UnitTests
             jurassicScriptEngine.SetGlobalValue("specialDate1", specialNowDate1);
 
             Assert.AreEqual(Evaluate("specialDate1.toUTCString()"), Evaluate("new Date(specialDate1.getTime()).toUTCString()"));
-            Assert.AreEqual(1451649599999d, Convert.ToDouble(Evaluate("specialDate1.getTime()")));
+            Assert.AreEqual(1451649599999d, Evaluate("specialDate1.getTime()"));
 
-            // Simulate "new Date" at 1969-12-31T23:59:59.9999999Z.
+            // Simulate "new Date()" at 1969-12-31T23:59:59.9999999Z.
             DateInstance specialNowDate2 = new DateInstance(jurassicScriptEngine.Date.InstancePrototype);
             dateInstanceValueField.SetValue(specialNowDate2, new DateTime(621355967999999999L, DateTimeKind.Utc));
             jurassicScriptEngine.SetGlobalValue("specialDate2", specialNowDate2);

--- a/Unit Tests/Library/DateTests.cs
+++ b/Unit Tests/Library/DateTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Jurassic.Library;
+using System.Globalization;
 
 namespace UnitTests
 {
@@ -85,13 +86,13 @@ namespace UnitTests
             // Date() returns the current date as a string - this test assumes the running time is less than 1s.
             var str = (string)Evaluate("Date()");
                 var formatString = "ddd MMM dd yyyy HH:mm:ss";
-                Assert.IsTrue(str.StartsWith(DateTime.Now.ToString(formatString)) || str.StartsWith(DateTime.Now.AddSeconds(1).ToString(formatString)),
+                Assert.IsTrue(str.StartsWith(DateTime.Now.ToString(formatString, CultureInfo.InvariantCulture)) || str.StartsWith(DateTime.Now.AddSeconds(1).ToString(formatString)),
                     string.Format("Expected: {0} Was: {1}", DateTime.Now.ToString(formatString), str));
 
             // Any arguments provided are ignored.
             str = (string)Evaluate("Date(2009)");
-                Assert.IsTrue(str.StartsWith(DateTime.Now.ToString("ddd MMM dd yyyy HH:mm:ss")) ||
-                    str.StartsWith(DateTime.Now.AddSeconds(1).ToString("ddd MMM dd yyyy HH:mm:ss")));
+                Assert.IsTrue(str.StartsWith(DateTime.Now.ToString("ddd MMM dd yyyy HH:mm:ss", CultureInfo.InvariantCulture)) ||
+                    str.StartsWith(DateTime.Now.AddSeconds(1).ToString("ddd MMM dd yyyy HH:mm:ss", CultureInfo.InvariantCulture)));
 
             // toString and valueOf.
             Assert.AreEqual("function Date() { [native code] }", Evaluate("Date.toString()"));


### PR DESCRIPTION
When running `new Date()` in Jurassic, the `DateInstance` uses `DateTime.Now` which can have fractional milliseconds as the DateTime's resolution is 100-nanoseconds.

For example, if `dateTime.ToString("o")` (.Net) was `2016-01-01T11:59:59.9999999Z`, `date.toUTCString()` (JS) would have returned `Fri, 01 Jan 2016 11:59:59 GMT` but `new Date(date.getTime()).toUTCString()` would have returned `Fri, 01 Jan 2016 12:00:00 GMT` which represents a greater value than the actual date.

This fixes the additional points in #65 by using a conversion that is consistent with `DateTimeOffset.ToUnixTimeMilliseconds()`.

Note: I used reflection in the test to set the `DateInstance.value` field as it is not public. Maybe DateInstance could have a constructor where you can supply a DateTime directly.

Thanks!