### PR TITLE
Allow to set a custom TimeZoneInfo on the ScriptEngine

### DIFF
--- a/Jurassic/Core/ScriptEngine.cs
+++ b/Jurassic/Core/ScriptEngine.cs
@@ -13,6 +13,9 @@ namespace Jurassic
         // Compatibility mode.
         private CompatibilityMode compatibilityMode;
 
+        // The TimeZoneInfo used by DateInstance.
+        private TimeZoneInfo timeZone = TimeZoneInfo.Local;
+
         // The initial hidden class schema.
         private HiddenClassSchema emptySchema;
 
@@ -217,6 +220,22 @@ namespace Jurassic
                 this.Global.FastSetProperty("Infinity", double.PositiveInfinity, attributes, overwriteAttributes: true);
                 this.Global.FastSetProperty("NaN", double.NaN, attributes, overwriteAttributes: true);
                 this.Global.FastSetProperty("undefined", Undefined.Value, attributes, overwriteAttributes: true);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="TimeZoneInfo"/> that is used to convert between UTC and
+        /// a local timezone.
+        /// The default value is <see cref="TimeZoneInfo.Local"/>.
+        /// </summary>
+        public TimeZoneInfo TimeZone
+        {
+            get { return this.timeZone; }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("value");
+                this.timeZone = value;
             }
         }
 

--- a/Jurassic/Core/ScriptEngine.cs
+++ b/Jurassic/Core/ScriptEngine.cs
@@ -14,7 +14,7 @@ namespace Jurassic
         private CompatibilityMode compatibilityMode;
 
         // The TimeZoneInfo used by DateInstance.
-        private TimeZoneInfo timeZone = TimeZoneInfo.Local;
+        private TimeZoneInfo localTimeZone = TimeZoneInfo.Local;
 
         // The initial hidden class schema.
         private HiddenClassSchema emptySchema;
@@ -225,17 +225,17 @@ namespace Jurassic
 
         /// <summary>
         /// Gets or sets the <see cref="TimeZoneInfo"/> that is used to convert between UTC and
-        /// a local timezone.
+        /// local time.
         /// The default value is <see cref="TimeZoneInfo.Local"/>.
         /// </summary>
-        public TimeZoneInfo TimeZone
+        public TimeZoneInfo LocalTimeZone
         {
-            get { return this.timeZone; }
+            get { return this.localTimeZone; }
             set
             {
                 if (value == null)
                     throw new ArgumentNullException("value");
-                this.timeZone = value;
+                this.localTimeZone = value;
             }
         }
 

--- a/Jurassic/Library/Date/DateConstructor.cs
+++ b/Jurassic/Library/Date/DateConstructor.cs
@@ -38,7 +38,7 @@ namespace Jurassic.Library
         [JSCallFunction]
         public string Call()
         {
-            return DateInstance.ToString(new DateInstance(this.InstancePrototype));
+            return DateInstance.ToString(Engine, new DateInstance(this.InstancePrototype));
         }
 
         /// <summary>
@@ -162,11 +162,11 @@ namespace Jurassic.Library
         /// 
         /// If any of the parameters are out of range, then the other values are modified accordingly.
         /// </remarks>
-        [JSInternalFunction(Name = "UTC")]
-        public static double UTC(int year, int month, int day = 1, int hour = 0,
+        [JSInternalFunction(Name = "UTC", Flags = JSFunctionFlags.HasEngineParameter)]
+        public static double UTC(ScriptEngine engine, int year, int month, int day = 1, int hour = 0,
             int minute = 0, int second = 0, int millisecond = 0)
         {
-            return DateInstance.UTC(year, month, day, hour, minute, second, millisecond);
+            return DateInstance.UTC(engine, year, month, day, hour, minute, second, millisecond);
         }
 
         /// <summary>
@@ -174,10 +174,10 @@ namespace Jurassic.Library
         /// January 1, 1970, 00:00:00 UTC.
         /// </summary>
         /// <param name="dateStr"> A string representing a date, expressed in RFC 1123 format. </param>
-        [JSInternalFunction(Name = "parse")]
-        public static double Parse(string dateStr)
+        [JSInternalFunction(Name = "parse", Flags = JSFunctionFlags.HasEngineParameter)]
+        public static double Parse(ScriptEngine engine, string dateStr)
         {
-            return DateInstance.Parse(dateStr);
+            return DateInstance.Parse(engine, dateStr);
         }
     }
 }

--- a/Jurassic/Library/Date/DateConstructor.g.cs
+++ b/Jurassic/Library/Date/DateConstructor.g.cs
@@ -52,21 +52,21 @@ namespace Jurassic.Library
 			switch (args.Length)
 			{
 				case 0:
-					return UTC(0, 0, 1, 0, 0, 0, 0);
+					return UTC(engine, 0, 0, 1, 0, 0, 0, 0);
 				case 1:
-					return UTC(TypeConverter.ToInteger(args[0]), 0, 1, 0, 0, 0, 0);
+					return UTC(engine, TypeConverter.ToInteger(args[0]), 0, 1, 0, 0, 0, 0);
 				case 2:
-					return UTC(TypeConverter.ToInteger(args[0]), TypeConverter.ToInteger(args[1]), 1, 0, 0, 0, 0);
+					return UTC(engine, TypeConverter.ToInteger(args[0]), TypeConverter.ToInteger(args[1]), 1, 0, 0, 0, 0);
 				case 3:
-					return UTC(TypeConverter.ToInteger(args[0]), TypeConverter.ToInteger(args[1]), TypeUtilities.IsUndefined(args[2]) ? 1 : TypeConverter.ToInteger(args[2]), 0, 0, 0, 0);
+					return UTC(engine, TypeConverter.ToInteger(args[0]), TypeConverter.ToInteger(args[1]), TypeUtilities.IsUndefined(args[2]) ? 1 : TypeConverter.ToInteger(args[2]), 0, 0, 0, 0);
 				case 4:
-					return UTC(TypeConverter.ToInteger(args[0]), TypeConverter.ToInteger(args[1]), TypeUtilities.IsUndefined(args[2]) ? 1 : TypeConverter.ToInteger(args[2]), TypeUtilities.IsUndefined(args[3]) ? 0 : TypeConverter.ToInteger(args[3]), 0, 0, 0);
+					return UTC(engine, TypeConverter.ToInteger(args[0]), TypeConverter.ToInteger(args[1]), TypeUtilities.IsUndefined(args[2]) ? 1 : TypeConverter.ToInteger(args[2]), TypeUtilities.IsUndefined(args[3]) ? 0 : TypeConverter.ToInteger(args[3]), 0, 0, 0);
 				case 5:
-					return UTC(TypeConverter.ToInteger(args[0]), TypeConverter.ToInteger(args[1]), TypeUtilities.IsUndefined(args[2]) ? 1 : TypeConverter.ToInteger(args[2]), TypeUtilities.IsUndefined(args[3]) ? 0 : TypeConverter.ToInteger(args[3]), TypeUtilities.IsUndefined(args[4]) ? 0 : TypeConverter.ToInteger(args[4]), 0, 0);
+					return UTC(engine, TypeConverter.ToInteger(args[0]), TypeConverter.ToInteger(args[1]), TypeUtilities.IsUndefined(args[2]) ? 1 : TypeConverter.ToInteger(args[2]), TypeUtilities.IsUndefined(args[3]) ? 0 : TypeConverter.ToInteger(args[3]), TypeUtilities.IsUndefined(args[4]) ? 0 : TypeConverter.ToInteger(args[4]), 0, 0);
 				case 6:
-					return UTC(TypeConverter.ToInteger(args[0]), TypeConverter.ToInteger(args[1]), TypeUtilities.IsUndefined(args[2]) ? 1 : TypeConverter.ToInteger(args[2]), TypeUtilities.IsUndefined(args[3]) ? 0 : TypeConverter.ToInteger(args[3]), TypeUtilities.IsUndefined(args[4]) ? 0 : TypeConverter.ToInteger(args[4]), TypeUtilities.IsUndefined(args[5]) ? 0 : TypeConverter.ToInteger(args[5]), 0);
+					return UTC(engine, TypeConverter.ToInteger(args[0]), TypeConverter.ToInteger(args[1]), TypeUtilities.IsUndefined(args[2]) ? 1 : TypeConverter.ToInteger(args[2]), TypeUtilities.IsUndefined(args[3]) ? 0 : TypeConverter.ToInteger(args[3]), TypeUtilities.IsUndefined(args[4]) ? 0 : TypeConverter.ToInteger(args[4]), TypeUtilities.IsUndefined(args[5]) ? 0 : TypeConverter.ToInteger(args[5]), 0);
 				default:
-					return UTC(TypeConverter.ToInteger(args[0]), TypeConverter.ToInteger(args[1]), TypeUtilities.IsUndefined(args[2]) ? 1 : TypeConverter.ToInteger(args[2]), TypeUtilities.IsUndefined(args[3]) ? 0 : TypeConverter.ToInteger(args[3]), TypeUtilities.IsUndefined(args[4]) ? 0 : TypeConverter.ToInteger(args[4]), TypeUtilities.IsUndefined(args[5]) ? 0 : TypeConverter.ToInteger(args[5]), TypeUtilities.IsUndefined(args[6]) ? 0 : TypeConverter.ToInteger(args[6]));
+					return UTC(engine, TypeConverter.ToInteger(args[0]), TypeConverter.ToInteger(args[1]), TypeUtilities.IsUndefined(args[2]) ? 1 : TypeConverter.ToInteger(args[2]), TypeUtilities.IsUndefined(args[3]) ? 0 : TypeConverter.ToInteger(args[3]), TypeUtilities.IsUndefined(args[4]) ? 0 : TypeConverter.ToInteger(args[4]), TypeUtilities.IsUndefined(args[5]) ? 0 : TypeConverter.ToInteger(args[5]), TypeUtilities.IsUndefined(args[6]) ? 0 : TypeConverter.ToInteger(args[6]));
 			}
 		}
 
@@ -75,9 +75,9 @@ namespace Jurassic.Library
 			switch (args.Length)
 			{
 				case 0:
-					return Parse("undefined");
+					return Parse(engine, "undefined");
 				default:
-					return Parse(TypeConverter.ToString(args[0]));
+					return Parse(engine, TypeConverter.ToString(args[0]));
 			}
 		}
 	}

--- a/Jurassic/Library/Date/DateInstance.cs
+++ b/Jurassic/Library/Date/DateInstance.cs
@@ -243,7 +243,7 @@ namespace Jurassic.Library
         {
             if (this.value == InvalidDate)
                 return double.NaN;
-            return -(int)Engine.TimeZone.GetUtcOffset(this.Value).TotalMinutes;
+            return -(int)Engine.LocalTimeZone.GetUtcOffset(this.Value).TotalMinutes;
         }
 
         /// <summary>
@@ -1217,7 +1217,7 @@ namespace Jurassic.Library
         /// <returns> A string of the form "GMT+1200 (New Zealand Standard Time)". </returns>
         private static string ToTimeZoneString(ScriptEngine engine, DateTime dateTime)
         {
-            var timeZone = engine.TimeZone;
+            var timeZone = engine.LocalTimeZone;
 
             // Compute the time zone offset in hours-minutes.
             int offsetInMinutes = (int)timeZone.GetUtcOffset(dateTime).TotalMinutes;
@@ -1241,7 +1241,7 @@ namespace Jurassic.Library
             if (value == InvalidDate)
                 return value;
 
-            value = TimeZoneInfo.ConvertTimeFromUtc(value, engine.TimeZone);
+            value = TimeZoneInfo.ConvertTimeFromUtc(value, engine.LocalTimeZone);
 
             // Ensure that the kind is local for consistency.
             if (value.Kind == DateTimeKind.Unspecified)
@@ -1259,11 +1259,11 @@ namespace Jurassic.Library
             // timezone is not reference-equal to TimeZoneInfo.Local.
             if (value.Kind == DateTimeKind.Utc)
                 return value;
-            if (object.ReferenceEquals(TimeZoneInfo.Local, engine.TimeZone))
+            if (object.ReferenceEquals(TimeZoneInfo.Local, engine.LocalTimeZone))
                 value = DateTime.SpecifyKind(value, DateTimeKind.Local);
             else
                 value = DateTime.SpecifyKind(value, DateTimeKind.Unspecified);
-            return TimeZoneInfo.ConvertTimeToUtc(value, engine.TimeZone);
+            return TimeZoneInfo.ConvertTimeToUtc(value, engine.LocalTimeZone);
         }
 
     }

--- a/Jurassic/Library/Date/DateInstance.g.cs
+++ b/Jurassic/Library/Date/DateInstance.g.cs
@@ -539,7 +539,7 @@ namespace Jurassic.Library
 
 		private static object __STUB__ToString(ScriptEngine engine, object thisObj, object[] args)
 		{
-			return ToString(thisObj);
+			return ToString(engine, thisObj);
 		}
 
 		private static object __STUB__ToTimeString(ScriptEngine engine, object thisObj, object[] args)

--- a/Unit Tests/Library/DateTests.cs
+++ b/Unit Tests/Library/DateTests.cs
@@ -700,8 +700,56 @@ namespace UnitTests
             Assert.AreEqual(true, ((DateInstance)Evaluate("new Date()")).IsValid);
         }
 
+        [TestMethod]
+        public void TimeZone()
+        {
+            // Initialize Engine
+            Evaluate("");
+
+            var date = new DateTime(2010, 4, 24, 23, 59, 57, DateTimeKind.Utc);
+            var dateExpr = "new Date(Date.UTC(2010, 3, 24, 23, 59, 57))";
+
+            
+            // UTC-03:00
+            jurassicScriptEngine.TimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific SA Standard Time");
+            Assert.AreEqual(ToJSDate(date), Evaluate(dateExpr + ".getTime()"));
+            Assert.AreEqual(23, Evaluate(dateExpr + ".getUTCHours()"));
+            Assert.AreEqual(19, Evaluate(dateExpr + ".getHours()"));
+            Assert.AreEqual(4 * 60, Evaluate(dateExpr + ".getTimezoneOffset()"));
+
+            Assert.AreEqual("2010-04-24T23:59:57.000Z", Evaluate("new Date(2010, 3, 24, 19, 59, 57).toISOString()"));
+            Assert.AreEqual(ToJSDate(date), Evaluate("new Date(2010, 3, 24, 19, 59, 57).getTime()"));
+
+            // Daylight Saving Time
+            Assert.AreEqual(3 * 60, Evaluate("new Date(2010, 0, 24, 23, 59, 57).getTimezoneOffset()"));
+
+            // UTC+11:00
+            jurassicScriptEngine.TimeZone = TimeZoneInfo.FindSystemTimeZoneById("Central Pacific Standard Time");
+
+            Assert.AreEqual(ToJSDate(date), Evaluate(dateExpr + ".getTime()"));
+            Assert.AreEqual(23, Evaluate(dateExpr + ".getUTCHours()"));
+            Assert.AreEqual(10, Evaluate(dateExpr + ".getHours()"));
+            Assert.AreEqual(-11 * 60, Evaluate(dateExpr + ".getTimezoneOffset()"));
+
+            Assert.AreEqual(ToJSDate(date), Evaluate("new Date(2010, 3, 25, 10, 59, 57).getTime()"));
+
+            // Custom UTC Timezone
+            jurassicScriptEngine.TimeZone = TimeZoneInfo.CreateCustomTimeZone("My Custom UTC",
+                new TimeSpan(0, 0, 0), "My Custom UTC Zone", "My Custom UTC Display Name");
+            Assert.AreEqual("Thu Jan 01 1970 00:00:00 GMT+0000 (My Custom UTC Display Name)", Evaluate("new Date(0).toString()"));
+
+            // Check that the differentiation between DateTimeKind.Local and DateTimeKind.Unspecified works
+            // when using a copy of the local timezone.
+            jurassicScriptEngine.TimeZone = TimeZoneInfo.FindSystemTimeZoneById(TimeZoneInfo.Local.Id);
+            Assert.AreEqual(ToJSDate(new DateTime(2010, 4, 24, 23, 59, 57, DateTimeKind.Local)),
+                Evaluate("new Date(2010, 3, 24, 23, 59, 57).getTime()"));
 
 
+            // Restore local timezone.
+            jurassicScriptEngine.TimeZone = TimeZoneInfo.Local;
+        }
+
+        
 
 
         private static object ToJSDate(DateTime dateTime)

--- a/Unit Tests/Library/DateTests.cs
+++ b/Unit Tests/Library/DateTests.cs
@@ -711,7 +711,7 @@ namespace UnitTests
 
             
             // UTC-03:00
-            jurassicScriptEngine.TimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific SA Standard Time");
+            jurassicScriptEngine.LocalTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific SA Standard Time");
             Assert.AreEqual(ToJSDate(date), Evaluate(dateExpr + ".getTime()"));
             Assert.AreEqual(23, Evaluate(dateExpr + ".getUTCHours()"));
             Assert.AreEqual(19, Evaluate(dateExpr + ".getHours()"));
@@ -724,7 +724,7 @@ namespace UnitTests
             Assert.AreEqual(3 * 60, Evaluate("new Date(2010, 0, 24, 23, 59, 57).getTimezoneOffset()"));
 
             // UTC+11:00
-            jurassicScriptEngine.TimeZone = TimeZoneInfo.FindSystemTimeZoneById("Central Pacific Standard Time");
+            jurassicScriptEngine.LocalTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Central Pacific Standard Time");
 
             Assert.AreEqual(ToJSDate(date), Evaluate(dateExpr + ".getTime()"));
             Assert.AreEqual(23, Evaluate(dateExpr + ".getUTCHours()"));
@@ -734,19 +734,19 @@ namespace UnitTests
             Assert.AreEqual(ToJSDate(date), Evaluate("new Date(2010, 3, 25, 10, 59, 57).getTime()"));
 
             // Custom UTC Timezone
-            jurassicScriptEngine.TimeZone = TimeZoneInfo.CreateCustomTimeZone("My Custom UTC",
+            jurassicScriptEngine.LocalTimeZone = TimeZoneInfo.CreateCustomTimeZone("My Custom UTC",
                 new TimeSpan(0, 0, 0), "My Custom UTC Zone", "My Custom UTC Display Name");
             Assert.AreEqual("Thu Jan 01 1970 00:00:00 GMT+0000 (My Custom UTC Display Name)", Evaluate("new Date(0).toString()"));
 
             // Check that the differentiation between DateTimeKind.Local and DateTimeKind.Unspecified works
             // when using a copy of the local timezone.
-            jurassicScriptEngine.TimeZone = TimeZoneInfo.FindSystemTimeZoneById(TimeZoneInfo.Local.Id);
+            jurassicScriptEngine.LocalTimeZone = TimeZoneInfo.FindSystemTimeZoneById(TimeZoneInfo.Local.Id);
             Assert.AreEqual(ToJSDate(new DateTime(2010, 4, 24, 23, 59, 57, DateTimeKind.Local)),
                 Evaluate("new Date(2010, 3, 24, 23, 59, 57).getTime()"));
 
 
             // Restore local timezone.
-            jurassicScriptEngine.TimeZone = TimeZoneInfo.Local;
+            jurassicScriptEngine.LocalTimeZone = TimeZoneInfo.Local;
         }
 
         


### PR DESCRIPTION
Hi,

it would be cool if Jurassic's `ScriptEngine` allows to set a custom `TimeZoneInfo` used to convert between UTC and local time. This is useful for example if you run user-defined scripts on a server, but each script should run with the user's timezone (Jint also allows to set the engine's timezone).

While setting the current `CultureInfo` (for number-formatting etc.) can be done on the current thread (so this works without modifying the `ScriptEngine`), there is not thread-specific timezone setting, so this would need to be done on the `ScriptEngine` level.

This PR creates a new property `ScriptEngine.LocalTimeZone` where a custom timezone can be set, which is then used by the `DateInstance`. The default value is `TimeZoneInfo.Local`.

Thanks!