### PR TITLE
Fix ToJSDate() conversion

### DIFF
--- a/Jurassic/Library/Date/DateInstance.cs
+++ b/Jurassic/Library/Date/DateInstance.cs
@@ -77,7 +77,7 @@ namespace Jurassic.Library
         /// </summary>
         /// <param name="prototype"> The next object in the prototype chain. </param>
         /// <param name="dateTime"> The date to set the instance value to. </param>
-        private DateInstance(ObjectInstance prototype, DateTime dateTime)
+        public DateInstance(ObjectInstance prototype, DateTime dateTime)
             : base(prototype)
         {
             this.value = dateTime;

--- a/Jurassic/Library/Date/DateInstance.cs
+++ b/Jurassic/Library/Date/DateInstance.cs
@@ -1113,7 +1113,9 @@ namespace Jurassic.Library
                 return double.NaN;
             // The spec requires that the time value is an integer.
             // We could round to nearest, but then date.toUTCString() would be different from Date(date.getTime()).toUTCString().
-            return Math.Floor(dateTime.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds);
+            // We do a integer division before subtracting the dates to ensure the behavior is like Math.Floor().
+            return dateTime.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond -
+                new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks / TimeSpan.TicksPerMillisecond;
         }
 
         /// <summary>

--- a/Unit Tests/Library/DateTests.cs
+++ b/Unit Tests/Library/DateTests.cs
@@ -728,7 +728,8 @@ namespace UnitTests
 
         private static object ToJSDate(DateTime dateTime)
         {
-            var result = Math.Floor(dateTime.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds);
+            double result = dateTime.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond -
+                new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks / TimeSpan.TicksPerMillisecond;
             if ((double)(int)result == result)
                 return (int)result;
             return result;

--- a/Unit Tests/Library/DateTests.cs
+++ b/Unit Tests/Library/DateTests.cs
@@ -700,6 +700,28 @@ namespace UnitTests
             Assert.AreEqual(true, ((DateInstance)Evaluate("new Date()")).IsValid);
         }
 
+        [TestMethod]
+        public void DateConversion()
+        {
+            // Init Jurassic
+            Evaluate("");
+
+            // Simulate "new Date()" (which uses DateTime.Now) at 2016-01-01T11:59:59.9999999Z.
+            DateInstance specialNowDate1 = new DateInstance(jurassicScriptEngine.Date.InstancePrototype,
+                new DateTime(635872463999999999L, DateTimeKind.Utc));
+            jurassicScriptEngine.SetGlobalValue("specialDate1", specialNowDate1);
+
+            Assert.AreEqual(Evaluate("specialDate1.toUTCString()"), Evaluate("new Date(specialDate1.getTime()).toUTCString()"));
+            Assert.AreEqual(1451649599999d, Evaluate("specialDate1.getTime()"));
+
+            // Simulate "new Date()" at 1969-12-31T23:59:59.9999999Z.
+            DateInstance specialNowDate2 = new DateInstance(jurassicScriptEngine.Date.InstancePrototype,
+                new DateTime(621355967999999999L, DateTimeKind.Utc));
+            jurassicScriptEngine.SetGlobalValue("specialDate2", specialNowDate2);
+
+            Assert.AreEqual(-1, Evaluate("specialDate2.getTime()"));
+        }
+
 
 
 


### PR DESCRIPTION
Hi,
this fixes the remaining issue of #66 by ensuring `date.toUTCString() == new Date(date.getTime()).toUTCString()`.

I changed the visibility of the `DateInstance(ObjectInstance, DateTime)` constructor to `public` to allow to create a test for a specific `DateTime` value, without having to use reflection, if that's OK.

Thanks!
