### PR TITLE
Implement "FunctionInstance.ConstructWithStackTrace()" and call this …

### DIFF
--- a/Jurassic/Compiler/Emit/ReflectionHelpers.cs
+++ b/Jurassic/Compiler/Emit/ReflectionHelpers.cs
@@ -39,7 +39,7 @@ namespace Jurassic.Compiler
         internal static MethodInfo TypeUtilities_Iterate;
 
         internal static MethodInfo FunctionInstance_HasInstance;
-        internal static MethodInfo FunctionInstance_ConstructLateBound;
+        internal static MethodInfo FunctionInstance_ConstructWithStackTrace;
         internal static MethodInfo FunctionInstance_CallWithStackTrace;
         internal static MethodInfo FunctionInstance_InstancePrototype;
 
@@ -196,7 +196,7 @@ namespace Jurassic.Compiler
             Scope_Delete = GetInstanceMethod(typeof(Scope), "Delete", typeof(string));
 
             FunctionInstance_HasInstance = GetInstanceMethod(typeof(FunctionInstance), "HasInstance", typeof(object));
-            FunctionInstance_ConstructLateBound = GetInstanceMethod(typeof(FunctionInstance), "ConstructLateBound", typeof(object[]));
+            FunctionInstance_ConstructWithStackTrace = GetInstanceMethod(typeof(FunctionInstance), "ConstructWithStackTrace", typeof(string), typeof(string), typeof(int), typeof(object[]));
             FunctionInstance_CallWithStackTrace = GetInstanceMethod(typeof(FunctionInstance), "CallWithStackTrace", typeof(string), typeof(string), typeof(int), typeof(object), typeof(object[]));
             FunctionInstance_InstancePrototype = GetInstanceMethod(typeof(FunctionInstance), "get_InstancePrototype");
 

--- a/Jurassic/Compiler/Expressions/NewExpression.cs
+++ b/Jurassic/Compiler/Expressions/NewExpression.cs
@@ -97,6 +97,11 @@ namespace Jurassic.Compiler
             generator.DefineLabelPosition(endOfTypeCheck);
             generator.ReleaseTemporaryVariable(targetValue);
 
+            // Pass in the path, function name and line.
+            generator.LoadStringOrNull(optimizationInfo.Source.Path);
+            generator.LoadStringOrNull(optimizationInfo.FunctionName);
+            generator.LoadInt32(optimizationInfo.SourceSpan.StartLine);
+
             if (operand is FunctionCallExpression)
             {
                 // Emit an array containing the function arguments.
@@ -110,7 +115,7 @@ namespace Jurassic.Compiler
             }
 
             // Call FunctionInstance.ConstructLateBound(argumentValues)
-            generator.Call(ReflectionHelpers.FunctionInstance_ConstructLateBound);
+            generator.Call(ReflectionHelpers.FunctionInstance_ConstructWithStackTrace);
         }
     }
 

--- a/Jurassic/Library/Function/FunctionInstance.cs
+++ b/Jurassic/Library/Function/FunctionInstance.cs
@@ -226,6 +226,27 @@ namespace Jurassic.Library
             return newObject;
         }
 
+        /// <summary>
+        /// Creates an object, using this function as the constructor.
+        /// </summary>
+        /// <param name="path"> The path of the javascript source file that contains the caller. </param>
+        /// <param name="function"> The name of the caller function. </param>
+        /// <param name="line"> The line number of the statement that is calling this function. </param>
+        /// <param name="argumentValues"> An array of argument values. </param>
+        /// <returns> The value that was returned from the function. </returns>
+        public ObjectInstance ConstructWithStackTrace(string path, string function, int line, object[] argumentValues)
+        {
+            this.Engine.PushStackFrame(path, function, line);
+            try
+            {
+                return ConstructLateBound(argumentValues);
+            }
+            finally
+            {
+                this.Engine.PopStackFrame();
+            }
+        }
+
 
 
         //     JAVASCRIPT FUNCTIONS

--- a/Jurassic/Library/Function/FunctionInstance.cs
+++ b/Jurassic/Library/Function/FunctionInstance.cs
@@ -233,7 +233,7 @@ namespace Jurassic.Library
         /// <param name="function"> The name of the caller function. </param>
         /// <param name="line"> The line number of the statement that is calling this function. </param>
         /// <param name="argumentValues"> An array of argument values. </param>
-        /// <returns> The value that was returned from the function. </returns>
+        /// <returns> The object that was created. </returns>
         public ObjectInstance ConstructWithStackTrace(string path, string function, int line, object[] argumentValues)
         {
             this.Engine.PushStackFrame(path, function, line);

--- a/Unit Tests/Library/ErrorTests.cs
+++ b/Unit Tests/Library/ErrorTests.cs
@@ -96,6 +96,27 @@ namespace UnitTests
                         return b(3, 4, '\n\n', undefined, {});
                     }
                     a('first call, firstarg');"));
+            Assert.AreEqual("Error: myError\r\n" +
+                "    at trace (unknown:4)\r\n" +
+                "    at b (unknown:11)\r\n" +
+                "    at a (unknown:14)\r\n" +
+                "    at unknown:16",
+                Evaluate(@"
+                    function trace() {
+                        try {
+                            throw new Error('myError');
+                        }
+                        catch (e) {
+                            return Object(e.stack);
+                        }
+                    }
+                    function b() {
+                        return new trace();
+                    }
+                    function a() {
+                        return new b(3, 4, '\n\n', undefined, {});
+                    }
+                    new a('first call, firstarg').valueOf();"));
             Assert.AreEqual("Error: this error is initialized at line 3, but thrown at line 5\r\n" +
                 "    at trace (unknown:5)\r\n" +
                 "    at unknown:11",


### PR DESCRIPTION
…instead of "ConstructLateBound()" in the NewExpression.

This ensures a stack frame is pushed onto the Engine.
Fixes #79