### PR TITLE
Use Multi-Targeting to support .NET 4.5

### DIFF
--- a/Jurassic/Jurassic.csproj
+++ b/Jurassic/Jurassic.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Authors>Paul Bartrum</Authors>
     <Company />
     <Description>A .NET library to parse and execute JavaScript code.</Description>
@@ -10,10 +10,18 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NETSTANDARD2_0</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETSTANDARD</DefineConstants>
+    <DocumentationFile>bin\Debug\$(TargetFramework)\Jurassic.xml</DocumentationFile>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETSTANDARD</DefineConstants>
+    <DocumentationFile>bin\Release\$(TargetFramework)\Jurassic.xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi,

Currently, Jurassic only targets .NET Standard 2.0 (`netstandard2.0`). I suggest to use multi-targeting to also target e.g. .NET Framework 4.5 (`net45`), since .NET Standard 2.0 is only supported by .NET 4.6.1 and higher.

I would also recommend to define the constant e.g. `NETSTANDARD` instead of `NETSTANDARD2_0`, to ensure you do not need to change it when you are targetting a higher .NET Standard version (note that `NETSTANDARD2_0` is currently automatically defined through the build process.

Thanks!