### PR TITLE
Fixed: Implicit undefined element in array raises 'value cannot be nu…

### DIFF
--- a/Jurassic/Library/Set/SetInstance.cs
+++ b/Jurassic/Library/Set/SetInstance.cs
@@ -84,6 +84,8 @@ namespace Jurassic.Library
         [JSInternalFunction(Name = "add")]
         public SetInstance Add(object value)
         {
+            value = value ?? Undefined.Value;
+
             if (this.store.ContainsKey(value))
                 return this;
             if (value is double && TypeUtilities.IsNegativeZero((double)value))

--- a/Unit Tests/Library/SetTests.cs
+++ b/Unit Tests/Library/SetTests.cs
@@ -21,6 +21,8 @@ namespace UnitTests
             // new Set();
             Assert.AreEqual(0, Evaluate("new Set().size"));
 
+            Assert.AreEqual(Undefined.Value, Evaluate("new Set([,1])[0]"));
+
             // new Set(iterable);
             Assert.AreEqual(4, Evaluate("new Set([2, 1, 1, 3, 5, 3, 2]).size"));
             Assert.AreEqual("2,1,3,5", Evaluate("Int8Array.from(new Set([2, 1, 1, 3, 5, 3, 2])).toString()"));


### PR DESCRIPTION
…ll exception' in Set.add()

If you pass an array with an implicit undefined element into "new Set()", it crashes with a 'value cannot be null exception'

eg:

new Set([,1]);

Still familiarising myself with the code so unsure if the best place to fix!