### PR TITLE
Added a `net461` target in test projects

### DIFF
--- a/Attribute Code Generation/Attribute Code Generation.csproj
+++ b/Attribute Code Generation/Attribute Code Generation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Benchmarker/Benchmarker.csproj
+++ b/Benchmarker/Benchmarker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Test Suite Runner/Test Suite Runner.csproj
+++ b/Test Suite Runner/Test Suite Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <RootNamespace>Jurassic.TestSuiteRunner</RootNamespace>
   </PropertyGroup>
 

--- a/Unit Tests/Unit Tests.csproj
+++ b/Unit Tests/Unit Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -10,6 +10,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is analog of the [“Fixed a errors that occurred during running unit tests for .NET Framework 4.5 version”](https://github.com/paulbartrum/jurassic/pull/123) pull request only without fixing the error.