### PR TITLE
Better CLR interop (for collections).

### DIFF
--- a/Jurassic/Compiler/Binders/ClrBinder.cs
+++ b/Jurassic/Compiler/Binders/ClrBinder.cs
@@ -297,6 +297,36 @@ namespace Jurassic.Compiler
                 generator.DefineLabelPosition(startOfElse);
             }
 
+            // Handle Nullable<>.
+            var isNullable = fromType.IsGenericType && fromType.GetGenericTypeDefinition() == typeof(Nullable<>);
+            if (isNullable)
+            {
+                endOfNullCheck = generator.CreateLabel();
+
+                var v = generator.CreateTemporaryVariable(fromType);
+                generator.StoreVariable(v);
+                generator.LoadAddressOfVariable(v);
+
+                var hasValue = ReflectionHelpers.GetInstanceMethod(fromType, "get_HasValue");
+                generator.Call(hasValue);
+                generator.BranchIfTrue(endOfNullCheck);
+                
+                // Return null.
+                generator.LoadNull();
+                generator.Return();
+                
+                // Jump here if it was NOT null.
+                generator.DefineLabelPosition(endOfNullCheck);
+
+                // Get the underlying value.
+                generator.LoadAddressOfVariable(v);
+                var getValue = ReflectionHelpers.GetInstanceMethod(fromType, "get_Value");
+                generator.Call(getValue);
+
+                // Now let the normal conversion work.
+                fromType = fromType.GenericTypeArguments[0];
+            }
+
             switch (Type.GetTypeCode(fromType))
             {
                 case TypeCode.Boolean:
@@ -354,7 +384,8 @@ namespace Jurassic.Compiler
                     if (fromType.IsValueType == true)
                         generator.Box(fromType);
                     generator.ReleaseTemporaryVariable(temp);
-                    generator.NewObject(ReflectionHelpers.ClrInstanceWrapper_Constructor);
+                    generator.CallStatic(ReflectionHelpers.ClrInstanceWrapper_Create);
+                    //generator.NewObject(ReflectionHelpers.ClrInstanceWrapper_Constructor);
                     
                     // End of wrap check.
                     if (fromType.IsValueType == false)

--- a/Jurassic/Compiler/Emit/ReflectionHelpers.cs
+++ b/Jurassic/Compiler/Emit/ReflectionHelpers.cs
@@ -89,6 +89,7 @@ namespace Jurassic.Compiler
         internal static MethodInfo MethodBase_GetMethodFromHandle;
         internal static MethodInfo GeneratedMethod_Load;
         internal static MethodInfo ClrInstanceWrapper_GetWrappedInstance;
+        internal static MethodInfo ClrInstanceWrapper_Create;
         internal static MethodInfo Decimal_ToDouble;
         internal static MethodInfo BinderUtilities_ResolveOverloads;
         internal static MethodInfo Convert_ToInt32_Double;
@@ -250,6 +251,7 @@ namespace Jurassic.Compiler
 
             GeneratedMethod_Load = GetStaticMethod(typeof(GeneratedMethod), "Load", typeof(long));
             ClrInstanceWrapper_GetWrappedInstance = GetInstanceMethod(typeof(ClrInstanceWrapper), "get_WrappedInstance");
+            ClrInstanceWrapper_Create = GetStaticMethod(typeof(ClrInstanceWrapper), "Create", new Type[] { typeof(ScriptEngine), typeof(object) });
             Decimal_ToDouble = GetStaticMethod(typeof(decimal), "ToDouble", typeof(decimal));
             BinderUtilities_ResolveOverloads = GetStaticMethod(typeof(BinderUtilities), "ResolveOverloads", typeof(RuntimeMethodHandle[]), typeof(ScriptEngine), typeof(object), typeof(object[]));
             Convert_ToInt32_Double = GetStaticMethod(typeof(Convert), "ToInt32", typeof(double));

--- a/Jurassic/Library/ClrWrapper/ClrInstanceWrapper.cs
+++ b/Jurassic/Library/ClrWrapper/ClrInstanceWrapper.cs
@@ -38,7 +38,26 @@ namespace Jurassic.Library
             return ClrInstanceTypeWrapper.FromCache(engine, instance.GetType());
         }
 
+      /// <summary>Creates an instance of ClrInstanceWrapper or ArrayInstance based on object type.</summary>
+      /// <param name="engine"></param>
+      /// <param name="instance"></param>
+      public static ObjectInstance Create(ScriptEngine engine, object instance)
+      {
+         if (typeof(System.Collections.IEnumerable).IsAssignableFrom(instance.GetType()))
+         {
+            var src = instance as System.Collections.IList;
+            var dst = new object[src.Count];
+            for (int i = 0; i<src.Count;i++)
+            {
+               var obj = src[i];
+               dst[i] = ClrInstanceWrapper.Create(engine, obj);
+            }
 
+            return engine.Array.New(dst);
+         }
+
+         return new ClrInstanceWrapper(engine, instance);
+      }
 
 
         //     PROPERTIES

--- a/Jurassic/Library/ClrWrapper/ClrInstanceWrapper.cs
+++ b/Jurassic/Library/ClrWrapper/ClrInstanceWrapper.cs
@@ -43,11 +43,12 @@ namespace Jurassic.Library
         /// <param name="instance"></param>
         public static ObjectInstance Create(ScriptEngine engine, object instance)
         {
-            if (typeof(System.Collections.IEnumerable).IsAssignableFrom(instance.GetType()))
+
+            var instanceAsIEnumerable = instance as System.Collections.IEnumerable;
+            if (instanceAsIEnumerable != null)
             {
-                var src = instance as System.Collections.IEnumerable;
                 var dst = new System.Collections.ArrayList();
-                var enumerator = src.GetEnumerator();
+                var enumerator = instanceAsIEnumerable.GetEnumerator();
                 while (enumerator.MoveNext()) {
                    var wrapped = ClrInstanceWrapper.Create(engine, enumerator.Current);
                    dst.Add(wrapped);

--- a/Jurassic/Library/ClrWrapper/ClrInstanceWrapper.cs
+++ b/Jurassic/Library/ClrWrapper/ClrInstanceWrapper.cs
@@ -38,27 +38,26 @@ namespace Jurassic.Library
             return ClrInstanceTypeWrapper.FromCache(engine, instance.GetType());
         }
 
-      /// <summary>Creates an instance of ClrInstanceWrapper or ArrayInstance based on object type.</summary>
-      /// <param name="engine"></param>
-      /// <param name="instance"></param>
-      public static ObjectInstance Create(ScriptEngine engine, object instance)
-      {
-         if (typeof(System.Collections.IEnumerable).IsAssignableFrom(instance.GetType()))
-         {
-            var src = instance as System.Collections.IList;
-            var dst = new object[src.Count];
-            for (int i = 0; i<src.Count;i++)
+        /// <summary>Creates an instance of ClrInstanceWrapper or ArrayInstance based on object type.</summary>
+        /// <param name="engine"></param>
+        /// <param name="instance"></param>
+        public static ObjectInstance Create(ScriptEngine engine, object instance)
+        {
+            if (typeof(System.Collections.IEnumerable).IsAssignableFrom(instance.GetType()))
             {
-               var obj = src[i];
-               dst[i] = ClrInstanceWrapper.Create(engine, obj);
+                var src = instance as System.Collections.IEnumerable;
+                var dst = new System.Collections.ArrayList();
+                var enumerator = src.GetEnumerator();
+                while (enumerator.MoveNext()) {
+                   var wrapped = ClrInstanceWrapper.Create(engine, enumerator.Current);
+                   dst.Add(wrapped);
+                }
+
+                return engine.Array.New(dst.ToArray());
             }
 
-            return engine.Array.New(dst);
-         }
-
-         return new ClrInstanceWrapper(engine, instance);
-      }
-
+            return new ClrInstanceWrapper(engine, instance);
+        }
 
         //     PROPERTIES
         //_________________________________________________________________________________________

--- a/Jurassic/Library/Function/UserDefinedFunction.cs
+++ b/Jurassic/Library/Function/UserDefinedFunction.cs
@@ -46,7 +46,14 @@ namespace Jurassic.Library
             var scope = DeclarativeScope.CreateFunctionScope(ObjectScope.CreateGlobalScope(this.Engine.Global), name, null);
 
             // Compile the code.
-            var context = new FunctionMethodGenerator(scope, name, argumentsText, bodyText, new CompilerOptions());
+            var context = new FunctionMethodGenerator(scope, name, argumentsText, bodyText, new CompilerOptions() {
+#if ENABLE_DEBUGGING
+               EnableDebugging = this.Engine.EnableDebugging,
+#endif
+               ForceStrictMode = this.Engine.ForceStrictMode,
+               EnableILAnalysis = this.Engine.EnableILAnalysis,
+               CompatibilityMode = this.Engine.CompatibilityMode
+            });
             try
             {
                 context.GenerateCode();


### PR DESCRIPTION
Better CLR interop.
* .NET collections are wrapped in `ObjectInstance`, which doesn't look like an array to Jurassic.
* Added a intermediate dispatch function `ClrInstanceWrapper.Create` which returns an `ArrayInstance` or `ObjectInstance` based on the .NET type.

Support for Nullable<>.
* Modified the CLR method generator so that it supports Nullable types.
* First it emits a call to `HasValue` and returns null if it doesn't.
* Then it emits a call to `GetValue` and lets the existing type conversion code run.

Also modified `UserDefinedFunction` so it shared CompilerOptions with the engine.