### PR TITLE
Change the type of the exception variable to 'object'

### DIFF
--- a/Jurassic/Compiler/Emit/ReflectionHelpers.cs
+++ b/Jurassic/Compiler/Emit/ReflectionHelpers.cs
@@ -199,7 +199,7 @@ namespace Jurassic.Compiler
             ScriptEngine_RegExp = GetInstanceMethod(typeof(ScriptEngine), "get_RegExp");
             ScriptEngine_Array = GetInstanceMethod(typeof(ScriptEngine), "get_Array");
             ScriptEngine_Object = GetInstanceMethod(typeof(ScriptEngine), "get_Object");
-            ScriptEngine_CanCatchException = GetInstanceMethod(typeof(ScriptEngine), "CanCatchException", typeof(Exception));
+            ScriptEngine_CanCatchException = GetInstanceMethod(typeof(ScriptEngine), "CanCatchException", typeof(object));
             Global_Eval = GetStaticMethod(typeof(GlobalObject), "Eval", typeof(ScriptEngine), typeof(object), typeof(Scope), typeof(object), typeof(bool));
 
             String_Constructor_Char_Int = GetConstructor(typeof(string), typeof(char), typeof(int));

--- a/Jurassic/Compiler/Statements/TryCatchFinallyStatement.cs
+++ b/Jurassic/Compiler/Statements/TryCatchFinallyStatement.cs
@@ -86,9 +86,20 @@ namespace Jurassic.Compiler
             var previousInsideTryCatchOrFinally = optimizationInfo.InsideTryCatchOrFinally;
             optimizationInfo.InsideTryCatchOrFinally = true;
 
-            // Finally requires two exception nested blocks.
+            // When we have a finally block, use a temporary variable that stores if the
+            // finally block should be skipped. This will be set to true when an exception was
+            // caught but ScriptEngine.CanCatchException() returns false.
+            // returns true.
+            ILLocalVariable skipFinallyBlock = null;
             if (this.FinallyBlock != null)
+            {
+                // Finally requires two exception nested blocks.
                 generator.BeginExceptionBlock();
+
+                skipFinallyBlock = generator.CreateTemporaryVariable(typeof(bool));
+                generator.LoadBoolean(false);
+                generator.StoreVariable(skipFinallyBlock);
+            }
 
             // Begin the exception block.
             generator.BeginExceptionBlock();
@@ -96,12 +107,10 @@ namespace Jurassic.Compiler
             // Generate code for the try block.
             this.TryBlock.GenerateCode(generator, optimizationInfo);
 
-            // Generate code for the catch block.
-            ILLocalVariable skipFinallyBlock = null;
-           
+            // Generate code for the catch block.           
             
             // Begin a catch block.  The exception is on the top of the stack.
-            generator.BeginCatchBlock(typeof(Exception));
+            generator.BeginCatchBlock(typeof(object));
 
             // Check the exception is catchable by calling CanCatchException(ex).
             // We need to handle the case where JS code calls into .NET code which then throws
@@ -109,7 +118,7 @@ namespace Jurassic.Compiler
             // If CatchBlock is null, we need to rethrow the exception in every case.
             var endOfIfLabel = generator.CreateLabel();
             generator.Duplicate();  // ex
-            var exceptionTemporary = generator.CreateTemporaryVariable(typeof(Exception));
+            var exceptionTemporary = generator.CreateTemporaryVariable(typeof(object));
             generator.StoreVariable(exceptionTemporary);
             EmitHelpers.LoadScriptEngine(generator);
             generator.LoadVariable(exceptionTemporary);
@@ -119,7 +128,6 @@ namespace Jurassic.Compiler
             if (this.FinallyBlock != null)
             {
                 generator.LoadBoolean(true);
-                skipFinallyBlock = generator.DeclareVariable(typeof(bool), "skipFinallyBlock");
                 generator.StoreVariable(skipFinallyBlock);
             }
             if (this.CatchBlock == null)
@@ -154,11 +162,12 @@ namespace Jurassic.Compiler
             {
                 generator.BeginFinallyBlock();
 
-                // If an exception was thrown that wasn't handled by the catch block, then don't
-                // run the finally block either.  This prevents user code from being run when a
-                // ThreadAbortException is thrown.
+                // If an exception was thrown that isn't determined as catchable by the ScriptEngine,
+                // then don't run the finally block either.  This prevents user code from being run
+                // when a non-JavaScriptException is thrown (e.g. to cancel script execution).
                 var endOfFinallyBlock = generator.CreateLabel();                
                 generator.LoadVariable(skipFinallyBlock);
+                generator.ReleaseTemporaryVariable(skipFinallyBlock);
                 generator.BranchIfTrue(endOfFinallyBlock);
 
                 var branches = new List<ILLabel>();

--- a/Jurassic/Core/ScriptEngine.cs
+++ b/Jurassic/Core/ScriptEngine.cs
@@ -1326,16 +1326,16 @@ namespace Jurassic
         }
 
         /// <summary>
-        /// Checks if the given <see cref="Exception"/> is catchable by JavaScript code with a
+        /// Checks if the given <paramref name="exception"/> is catchable by JavaScript code with a
         /// <c>catch</c> clause.
-        /// Note: This property is public for technical reasons only and should not be used by user code.
+        /// Note: This method is public for technical reasons only and should not be used by user code.
         /// </summary>
-        /// <param name="ex"> The exception to check. </param>
+        /// <param name="exception"> The exception to check. </param>
         /// <returns><c>true</c> if the <see cref="Exception"/> is catchable, <c>false otherwise</c></returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool CanCatchException(Exception ex)
+        public bool CanCatchException(object exception)
         {
-            var jsException = ex as JavaScriptException;
+            var jsException = exception as JavaScriptException;
             if (jsException == null)
                 return false;
             return jsException.Engine == this || jsException.Engine == null;


### PR DESCRIPTION
Hi,
this PR addresses the two notes described in #90.

By changing the type of the exception variable in the `catch` clause from `Exception` to `object`, it is ensured  that the `finally` block is also correctly skipped if objects are thrown that do not derive from `Exception` (which is possible in the CLR).

Note: When a non-`Exception` object is thrown and the control flow enters code generated by the C# compiler, the thrown object is wrapped in a [`RuntimeWrappedException`](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.runtimewrappedexception) so it can be caught by an `catch (Exception)` C# statement.
However, even with this I think it is safer to catch `object` in the generated IL code, to ensure JS `finally` blocks are not executed in such a case.

Additionally, the `skipFinallyBlock` variable is changed to a temporary variable.

Thanks!

