### PR TITLE
Displaying JavaScript like debugger information

### DIFF
--- a/Jurassic/Library/Array/ArrayInstance.cs
+++ b/Jurassic/Library/Array/ArrayInstance.cs
@@ -1,11 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// Represents an instance of the JavaScript Array object.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ArrayInstanceDebugView))]
     public partial class ArrayInstance : ObjectInstance
     {
         // The array, if it is dense.
@@ -198,6 +203,50 @@ namespace Jurassic.Library
             }
         }
 
+
+        private int GetLength()
+        {
+            return this.Properties.Where(pnv => (pnv.Key is string) && (pnv.Key as string) != "length").Count();
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get
+            {
+                IEnumerable<string> strValues = 
+                    this.Properties.Where(pnv => !((pnv.Key is string) && (pnv.Key as string) == "length")).
+                        Select(pnv=> DebuggerDisplayHelper.ShortStringRepresentation(pnv.Value));
+
+                return string.Format("[{0}]", string.Join(", ", strValues));
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get
+            {
+                string result = string.Format("Array({0})", this.GetLength());
+                return result;
+            }
+        }
+
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "Array"; }
+        }
 
 
         //     INTERNAL HELPER METHODS

--- a/Jurassic/Library/Array/ArrayIterator.cs
+++ b/Jurassic/Library/Array/ArrayIterator.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// Represents an iteration over an array-like object.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     internal partial class ArrayIterator : ObjectInstance
     {
         private ObjectInstance iteratedObject;
@@ -124,6 +127,33 @@ namespace Jurassic.Library
                 new PropertyNameAndValue("done", done, PropertyAttributes.FullAccess),
             });
             return result;
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return this.kind.ToString(); }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return this.ToStringTag; }
         }
     }
 }

--- a/Jurassic/Library/Boolean/BooleanInstance.cs
+++ b/Jurassic/Library/Boolean/BooleanInstance.cs
@@ -1,11 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// Represents an instance of the JavaScript Boolean object.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public partial class BooleanInstance : ObjectInstance
     {
         private bool value;
@@ -53,6 +57,35 @@ namespace Jurassic.Library
             get { return this.value; }
         }
 
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get
+            {
+                return this.Value.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "Boolean"; }
+        }
 
 
 

--- a/Jurassic/Library/ClrWrapper/ClrInstanceTypeWrapper.cs
+++ b/Jurassic/Library/ClrWrapper/ClrInstanceTypeWrapper.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
-using Jurassic.Compiler;
 
 namespace Jurassic.Library
 {
@@ -9,6 +8,8 @@ namespace Jurassic.Library
     /// Represents the instance portion of a CLR type that cannot be exposed directly but instead
     /// must be wrapped.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ClrInstanceTypeWrapperDebugView))]
     internal class ClrInstanceTypeWrapper : ObjectInstance
     {
 
@@ -78,6 +79,36 @@ namespace Jurassic.Library
         {
             get;
             private set;
+        }
+
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return this.WrappedType?.ToString(); }
+        }
+
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "Type"; }
         }
 
 

--- a/Jurassic/Library/ClrWrapper/ClrInstanceWrapper.cs
+++ b/Jurassic/Library/ClrWrapper/ClrInstanceWrapper.cs
@@ -1,12 +1,15 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// Represents a non-native CLR object instance.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ClrInstanceWrapperDebugView))]
     public class ClrInstanceWrapper : ObjectInstance
     {
 
@@ -68,6 +71,33 @@ namespace Jurassic.Library
         {
             get;
             private set;
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return this.WrappedInstance?.ToString(); }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return this.WrappedInstance?.GetType().ToString(); }
         }
 
 

--- a/Jurassic/Library/ClrWrapper/ClrStaticTypeWrapper.cs
+++ b/Jurassic/Library/ClrWrapper/ClrStaticTypeWrapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 using Jurassic.Compiler;
 
@@ -9,6 +10,8 @@ namespace Jurassic.Library
     /// Represents the static portion of a CLR type that cannot be exposed directly but instead
     /// must be wrapped.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ClrStaticTypeWrapperDebugView))]
     internal class ClrStaticTypeWrapper : FunctionInstance
     {
         private ClrBinder constructBinder;
@@ -103,6 +106,36 @@ namespace Jurassic.Library
         {
             get;
             private set;
+        }
+
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return this.WrappedType?.ToString(); }
+        }
+
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "Type"; }
         }
 
 

--- a/Jurassic/Library/Date/DateInstance.cs
+++ b/Jurassic/Library/Date/DateInstance.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// The prototype for the Date object.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public partial class DateInstance : ObjectInstance
     {
         /// <summary>
@@ -126,6 +129,36 @@ namespace Jurassic.Library
         public bool IsValid
         {
             get { return this.value != InvalidDate; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get
+            {
+                return DateInstance.ToString(this);
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "Date"; }
         }
 
 

--- a/Jurassic/Library/DebuggerDisplay/ArrayBufferInstanceDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/ArrayBufferInstanceDebugView.cs
@@ -1,0 +1,66 @@
+﻿using System.Diagnostics;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for ArrayBufferInstance
+    /// </summary>
+    public class ArrayBufferInstanceDebugView
+    {
+        /// <summary>
+        /// The displayed ArrayBufferInstance
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected ArrayBufferInstance arrayBufferInstance;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="arrayBufferInstance">The displayed ArrayBufferInstance</param>
+        public ArrayBufferInstanceDebugView(ArrayBufferInstance arrayBufferInstance)
+        {
+            this.arrayBufferInstance = arrayBufferInstance;
+        }
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.arrayBufferInstance.Prototype;
+            }
+        }
+
+        /// <summary>
+        /// ArrayBufferInstance properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.arrayBufferInstance.Properties.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Gets the length of ArrayBuffer in bytes
+        /// </summary>
+        public int byteLength
+        {
+            get { return this.arrayBufferInstance.Buffer.Length; }
+        }
+
+        /// <summary>
+        /// Gets the bytes array
+        /// </summary>
+        public byte[] Int8Array
+        {
+            get { return this.arrayBufferInstance.Buffer; }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/ArrayInstanceDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/ArrayInstanceDebugView.cs
@@ -1,0 +1,63 @@
+﻿using System.Diagnostics;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for ArrayInstance.
+    /// </summary>
+    public class ArrayInstanceDebugView
+    {
+        /// <summary>
+        /// The watched array
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected ArrayInstance arrayInstance;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="arrayInstance">The watched object</param>
+        public ArrayInstanceDebugView(ArrayInstance arrayInstance)
+        {
+            this.arrayInstance = arrayInstance;
+        }
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.arrayInstance.Prototype;
+            }
+        }
+
+
+        /// <summary>
+        /// Array properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.arrayInstance.Properties.Where(
+                    pnv => (pnv.Key is string) && (pnv.Key as string) != "length").ToArray();
+            }
+        }
+
+        /// <summary>
+        /// The count of array elements
+        /// </summary>
+        public uint length
+        {
+            get
+            {
+                return this.arrayInstance.Length;
+            }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/ClrInstanceTypeWrapperDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/ClrInstanceTypeWrapperDebugView.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Diagnostics;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debuger decorator for ClrInstanceTypeWrapper
+    /// </summary>
+    internal class ClrInstanceTypeWrapperDebugView
+    {
+        /// <summary>
+        /// The displayed object
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected ClrInstanceTypeWrapper clrInstanceTypeWrapper;
+
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="clrInstanceTypeWrapper">The displayed object</param>
+        public ClrInstanceTypeWrapperDebugView(ClrInstanceTypeWrapper clrInstanceTypeWrapper)
+        {
+            this.clrInstanceTypeWrapper = clrInstanceTypeWrapper;
+        }
+
+
+        /// <summary>
+        /// Original object
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        protected Type WrappedType
+        {
+            get
+            {
+                return this.clrInstanceTypeWrapper.WrappedType;
+            }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/ClrInstanceWrapperDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/ClrInstanceWrapperDebugView.cs
@@ -1,0 +1,38 @@
+﻿using System.Diagnostics;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for ClrInstanceWrapper
+    /// </summary>
+    public class ClrInstanceWrapperDebugView
+    {
+        /// <summary>
+        /// The displayed object
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected ClrInstanceWrapper clrInstanceWrapper;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="clrInstanceWrapper">The displayed object</param>
+        public ClrInstanceWrapperDebugView(ClrInstanceWrapper clrInstanceWrapper)
+        {
+            this.clrInstanceWrapper = clrInstanceWrapper;
+        }
+
+        /// <summary>
+        /// Original object
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        protected object WrappedInstance
+        {
+            get
+            {
+                return this.clrInstanceWrapper.WrappedInstance;
+            }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/ClrStaticTypeWrapperDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/ClrStaticTypeWrapperDebugView.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Diagnostics;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debuger decorator for ClrStaticTypeWrapper
+    /// </summary>
+    internal class ClrStaticTypeWrapperDebugView
+    {
+        /// <summary>
+        /// The displayed type
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected ClrStaticTypeWrapper clrStaticTypeWrapper;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="clrStaticTypeWrapper">The displayed type</param>
+        public ClrStaticTypeWrapperDebugView(ClrStaticTypeWrapper clrStaticTypeWrapper)
+        {
+            this.clrStaticTypeWrapper = clrStaticTypeWrapper;
+        }
+
+
+        /// <summary>
+        /// Original type
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        protected Type WrappedType
+        {
+            get
+            {
+                return this.clrStaticTypeWrapper.WrappedType;
+            }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/DataViewInstanceDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/DataViewInstanceDebugView.cs
@@ -1,0 +1,75 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for DataViewInstance
+    /// </summary>
+    public class DataViewInstanceDebugView
+    {
+        /// <summary>
+        /// The displayed DataViewInstance
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected DataViewInstance dataViewInstance;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="dataViewInstance">The displayed DataViewInstance</param>
+        public DataViewInstanceDebugView(DataViewInstance dataViewInstance)
+        {
+            this.dataViewInstance = dataViewInstance;
+        }
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.dataViewInstance.Prototype;
+            }
+        }
+
+        /// <summary>
+        /// DataViewInstance properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.dataViewInstance.Properties.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Gets the internal buffer
+        /// </summary>
+        public ArrayBufferInstance buffer
+        {
+            get { return this.dataViewInstance.Buffer; }
+        }
+
+        /// <summary>
+        /// Gets the buffer length in bytes
+        /// </summary>
+        public int byteLength
+        {
+            get { return this.dataViewInstance.Buffer.Buffer.Length; }
+        }
+
+        /// <summary>
+        /// Gets the buffer offset
+        /// </summary>
+        public int byteOffset
+        {
+            get { return this.dataViewInstance.ByteOffset; }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/DebuggerDisplayHelper.cs
+++ b/Jurassic/Library/DebuggerDisplay/DebuggerDisplayHelper.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
+
 
 namespace Jurassic.Library
 {

--- a/Jurassic/Library/DebuggerDisplay/DebuggerDisplayHelper.cs
+++ b/Jurassic/Library/DebuggerDisplay/DebuggerDisplayHelper.cs
@@ -22,6 +22,10 @@ namespace Jurassic.Library
             {
                 result = (value as ObjectInstance).DebuggerDisplayValue;
             }
+            else if (value is IDebuggerDisplay)
+            {
+                result = (value as IDebuggerDisplay).DebuggerDisplayValue;
+            }
             else if (value is string)
             {
                 result = string.Format("\"{0}\"", value);
@@ -55,6 +59,10 @@ namespace Jurassic.Library
             {
                 result = (value as ObjectInstance).DebuggerDisplayShortValue;
             }
+            else if (value is IDebuggerDisplay)
+            {
+                result = (value as IDebuggerDisplay).DebuggerDisplayShortValue;
+            }
             else if (value is string)
             {
                 result = string.Format("\"{0}\"", value);
@@ -85,6 +93,10 @@ namespace Jurassic.Library
             if (value is ObjectInstance)
             {
                 result = (value as ObjectInstance).DebuggerDisplayType;
+            }
+            else if (value is IDebuggerDisplay)
+            {
+                result = (value as IDebuggerDisplay).DebuggerDisplayType;
             }
             else
             {

--- a/Jurassic/Library/DebuggerDisplay/DebuggerDisplayHelper.cs
+++ b/Jurassic/Library/DebuggerDisplay/DebuggerDisplayHelper.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
-
+using System.Linq;
+using System.Text;
 
 namespace Jurassic.Library
 {
@@ -104,6 +106,22 @@ namespace Jurassic.Library
             }
             return result;
 
+        }
+
+        /// <summary>
+        /// Converts map contents to string
+        /// </summary>
+        /// <param name="mapStore">Internal storage of a MapInstance</param>
+        /// <returns>The result string</returns>
+        public static string MapRepresentation(Dictionary<object, LinkedListNode<KeyValuePair<object, object>>> mapStore)
+        {
+            IEnumerable<string> strValues =
+                mapStore.Values.Select(node =>
+                    string.Format("{0} => {1}",
+                        ShortStringRepresentation(node.Value.Key),
+                        ShortStringRepresentation(node.Value.Value)));
+
+            return string.Join(", ", strValues);
         }
     }
 }

--- a/Jurassic/Library/DebuggerDisplay/DebuggerDisplayHelper.cs
+++ b/Jurassic/Library/DebuggerDisplay/DebuggerDisplayHelper.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Jurassic.Library
@@ -122,6 +124,49 @@ namespace Jurassic.Library
                         ShortStringRepresentation(node.Value.Value)));
 
             return string.Join(", ", strValues);
+        }
+
+        /// <summary>
+        /// Gets the keys of a weak map using reflection
+        /// </summary>
+        /// <param name="weakMap">The WeakMapInstance</param>
+        /// <returns>Keys</returns>
+        public static IEnumerable<ObjectInstance> GetKeys(this ConditionalWeakTable<ObjectInstance, object> weakMap)
+        {
+            IEnumerable<ObjectInstance> keys = weakMap.GetType().InvokeMember(
+                                        "Keys",
+                                        BindingFlags.GetProperty | BindingFlags.Instance | BindingFlags.NonPublic,
+                                        null,
+                                        weakMap,
+                                        new object[] { }) as IEnumerable<ObjectInstance>;
+            return keys;
+        }
+
+        /// <summary>
+        /// Converts WeakMapInstance to its string representation
+        /// </summary>
+        /// <param name="sb">StringBuilder to add strings</param>
+        /// <param name="weakMapStore">Internal storage of a WeakMapInstance</param>
+        public static void WeakMapRepresentation(StringBuilder sb,
+            ConditionalWeakTable<ObjectInstance, object> weakMapStore)
+        {
+            bool comma = false;
+            IEnumerable<ObjectInstance> keys = weakMapStore.GetKeys();
+            foreach (ObjectInstance key in keys)
+            {
+                object value;
+                if (weakMapStore.TryGetValue(key, out value))
+                {
+                    if (comma)
+                    {
+                        sb.Append(", ");
+                    }
+                    sb.AppendFormat("{0} => {1}",
+                        DebuggerDisplayHelper.ShortStringRepresentation(key),
+                        DebuggerDisplayHelper.ShortStringRepresentation(value));
+                    comma = true;
+                }
+            }
         }
     }
 }

--- a/Jurassic/Library/DebuggerDisplay/DebuggerDisplayHelper.cs
+++ b/Jurassic/Library/DebuggerDisplay/DebuggerDisplayHelper.cs
@@ -74,5 +74,25 @@ namespace Jurassic.Library
             }
             return result;
         }
+
+        /// <summary>
+        /// Return decorated or actual Clr Type
+        /// </summary>
+        /// <param name="value">The object</param>
+        /// <returns>The name of the type</returns>
+        public static string TypeRepresentation(object value)
+        {
+            string result;
+            if (value is ObjectInstance)
+            {
+                result = (value as ObjectInstance).DebuggerDisplayType;
+            }
+            else
+            {
+                result = value?.GetType().Name;
+            }
+            return result;
+
+        }
     }
 }

--- a/Jurassic/Library/DebuggerDisplay/DebuggerDisplayHelper.cs
+++ b/Jurassic/Library/DebuggerDisplay/DebuggerDisplayHelper.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Helper methods used from debugger visualization
+    /// </summary>
+    public static class DebuggerDisplayHelper
+    {
+        /// <summary>
+        /// Converts any object to string, to be displayed in debugger watch window.
+        /// This is the long version, used when the object is directly displayed (not in parent).
+        /// </summary>
+        /// <param name="value">The object to be converted</param>
+        /// <returns>The result string</returns>
+        public static string StringRepresentation(object value)
+        {
+            string result;
+            if (value is ObjectInstance)
+            {
+                result = (value as ObjectInstance).DebuggerDisplayValue;
+            }
+            else if (value is string)
+            {
+                result = string.Format("\"{0}\"", value);
+            }
+            else
+            {
+                IFormattable formattable = value as IFormattable;
+                if (formattable == null)
+                {
+                    result = value.ToString();
+                }
+                else
+                {
+                    result = formattable.ToString(null, CultureInfo.InvariantCulture);
+                }
+            }
+            return result;
+        }
+
+
+        /// <summary>
+        /// Converts any object to string, to be displayed in debugger watch window.
+        /// This is the short version, used when the object is displayed as a child.
+        /// </summary>
+        /// <param name="value">The object to be converted</param>
+        /// <returns>The result string</returns>
+        public static string ShortStringRepresentation(object value)
+        {
+            string result;
+            if (value is ObjectInstance)
+            {
+                result = (value as ObjectInstance).DebuggerDisplayShortValue;
+            }
+            else if (value is string)
+            {
+                result = string.Format("\"{0}\"", value);
+            }
+            else
+            {
+                IFormattable formattable = value as IFormattable;
+                if (formattable == null)
+                {
+                    result = value.ToString();
+                }
+                else
+                {
+                    result = formattable.ToString(null, CultureInfo.InvariantCulture);
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/IDebuggerDisplay.cs
+++ b/Jurassic/Library/DebuggerDisplay/IDebuggerDisplay.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Interface for objects supporting decoration of the debugger information.
+    /// </summary>
+    public interface IDebuggerDisplay
+    {
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        string DebuggerDisplayValue { get; }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        string DebuggerDisplayShortValue { get; }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        string DebuggerDisplayType { get; }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/MapEntriesDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/MapEntriesDebugView.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for MapInstance entries.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    public class MapEntriesDebugView : IDebuggerDisplay
+    {
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private Dictionary<object, LinkedListNode<KeyValuePair<object, object>>> mapStore;
+
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private MapEntryDebugView[] entries;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="mapStore">Internal storage of the MapInstance</param>
+        public MapEntriesDebugView(Dictionary<object, LinkedListNode<KeyValuePair<object, object>>> mapStore)
+        {
+            this.mapStore = mapStore;
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayValue
+        {
+            get
+            {
+                return string.Format("[{0}]", DebuggerDisplayHelper.MapRepresentation(this.mapStore));
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayShortValue
+        {
+            get { return string.Format("Array({0})", this.mapStore.Count); }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayType
+        {
+            get { return this.DebuggerDisplayShortValue; }
+        }
+
+        /// <summary>
+        /// The MapInstance entries
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public MapEntryDebugView[] Entries
+        {
+            get
+            {
+                if (this.entries == null)
+                {
+                    this.entries = new MapEntryDebugView[this.mapStore.Count];
+                    int idx = 0;
+                    foreach (LinkedListNode<KeyValuePair<object, object>> value in this.mapStore.Values)
+                    {
+                        this.entries[idx++] = new MapEntryDebugView(value.Value);
+                    }
+                }
+
+                return this.entries;
+            }
+        }
+
+        /// <summary>
+        /// MapInstance entries count
+        /// </summary>
+        public int length
+        {
+            get { return this.mapStore.Count; }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/MapEntryDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/MapEntryDebugView.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for MapInstance entry.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    public class MapEntryDebugView : IDebuggerDisplay
+    {
+        /// <summary>
+        /// The displayed entry
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private KeyValuePair<object, object> entry;
+
+        /// <summary>
+        /// Key and value as PropertyNameAndValue Array
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private PropertyNameAndValue[] keyAndValue;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="entry">Entry key-value pair</param>
+        public MapEntryDebugView(KeyValuePair<object, object> entry)
+        {
+            this.entry = entry;
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayValue
+        {
+            get
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.Append("{");
+                sb.AppendFormat("{0} => {1}",
+                    DebuggerDisplayHelper.ShortStringRepresentation(this.entry.Key),
+                    DebuggerDisplayHelper.ShortStringRepresentation(this.entry.Value));
+                sb.Append("}");
+                return sb.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayType
+        {
+            get { return "Map Entry"; }
+        }
+
+
+        /// <summary>
+        /// Key and value as PropertyNameAndValue Array
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public PropertyNameAndValue[] KeyAndValue
+        {
+            get
+            {
+                if (this.keyAndValue == null)
+                {
+                    this.keyAndValue = new PropertyNameAndValue[2];
+                    this.keyAndValue[0] = new PropertyNameAndValue("key", this.entry.Key, PropertyAttributes.FullAccess);
+                    this.keyAndValue[1] = new PropertyNameAndValue("value", this.entry.Value, PropertyAttributes.FullAccess);
+                }
+
+                return this.keyAndValue;
+            }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/MapInstanceDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/MapInstanceDebugView.cs
@@ -1,0 +1,81 @@
+﻿using System.Diagnostics;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for MapInstance.
+    /// </summary>
+    public class MapInstanceDebugView
+    {
+        /// <summary>
+        /// The displayed map
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected MapInstance mapInstance;
+
+        /// <summary>
+        /// All entries
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected MapEntriesDebugView mapEntries;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="mapInstance">The displayed map</param>
+        public MapInstanceDebugView(MapInstance mapInstance)
+        {
+            this.mapInstance = mapInstance;
+        }
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.mapInstance.Prototype;
+            }
+        }
+
+        /// <summary>
+        /// Map entries count
+        /// </summary>
+        public int size
+        {
+            get
+            {
+                return this.mapInstance.Store.Count;
+            }
+        }
+
+        /// <summary>
+        /// Map properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.mapInstance.Properties.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Map entries list
+        /// </summary>
+        public MapEntriesDebugView Entries
+        {
+            get
+            {
+                if (this.mapEntries == null)
+                    this.mapEntries = new MapEntriesDebugView(this.mapInstance.Store);
+
+                return this.mapEntries;
+            }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/MapIteratorDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/MapIteratorDebugView.cs
@@ -1,0 +1,105 @@
+﻿using System.Diagnostics;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for MapIterator.
+    /// </summary>
+    public class MapIteratorDebugView
+    {
+        /// <summary>
+        /// The displayed iterator
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private MapIterator mapIterator;
+
+        /// <summary>
+        /// Decorator for the entries
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected object iteratorEntries;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="mapIterator">The displayed iterator</param>
+        internal MapIteratorDebugView(MapIterator mapIterator)
+        {
+            this.mapIterator = mapIterator;
+        }
+
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.mapIterator.Prototype;
+            }
+        }
+
+        /// <summary>
+        /// MapIterator properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.mapIterator.Properties.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Gets if iterator has more to iterate
+        /// </summary>
+        public bool IteratorHasMore
+        {
+            get { return !this.mapIterator.Done; }
+        }
+
+        /// <summary>
+        /// Get current index
+        /// </summary>
+        public int IteratorIndex
+        {
+            get { return this.mapIterator.IteratorIndex; }
+        }
+
+        /// <summary>
+        /// Get the iterator king as string - key, value or both
+        /// </summary>
+        public string IteratorKind
+        {
+            get { return this.mapIterator.IteratorKind.ToString(); }
+        }
+
+        /// <summary>
+        /// Gets a decorator for the entries
+        /// </summary>
+        public object Entries
+        {
+            get
+            {
+                if (this.iteratorEntries == null)
+                {
+                    if (this.mapIterator.IteratorKind == MapIterator.Kind.KeyAndValue)
+                    {
+                        this.iteratorEntries = new MapEntriesDebugView(this.mapIterator.Map.Store);
+                    }
+                    else
+                    {
+                        this.iteratorEntries = new MapKeyOrValuesDebugView(this.mapIterator.Map.Store,
+                            this.mapIterator.IteratorKind == MapIterator.Kind.Key);
+                    }
+                }
+
+                return this.iteratorEntries;
+            }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/MapKeyOrValuesDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/MapKeyOrValuesDebugView.cs
@@ -1,0 +1,113 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for MapIterator entries - key or value.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    public class MapKeyOrValuesDebugView : IDebuggerDisplay
+    {
+        /// <summary>
+        /// Internal Map storage
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private Dictionary<object, LinkedListNode<KeyValuePair<object, object>>> mapStore;
+
+        /// <summary>
+        /// Entries
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private PropertyNameAndValue[] values;
+
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private bool displayKeys;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="mapStore">Internal Map storage</param>
+        /// <param name="displayKeys">What to display - keys or values</param>
+        public MapKeyOrValuesDebugView(Dictionary<object, LinkedListNode<KeyValuePair<object, object>>> mapStore, bool displayKeys)
+        {
+            this.mapStore = mapStore;
+            this.displayKeys = displayKeys;
+        }
+
+        private void InitValues()
+        {
+            if (this.values == null)
+            {
+                this.values = new PropertyNameAndValue[this.mapStore.Count];
+                int idx = 0;
+                foreach (LinkedListNode<KeyValuePair<object, object>> value in this.mapStore.Values)
+                {
+                    this.values[idx] = new PropertyNameAndValue(idx++.ToString(CultureInfo.InvariantCulture),
+                        this.displayKeys ? value.Value.Key : value.Value.Value, PropertyAttributes.FullAccess);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayValue
+        {
+            get
+            {
+                this.InitValues();
+
+                IEnumerable<string> strValues =
+                    this.values.Select(pnv => DebuggerDisplayHelper.ShortStringRepresentation(pnv.Value));
+
+                return string.Format("[{0}]", string.Join(", ", strValues));
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayShortValue
+        {
+            get { return string.Format("Array({0})", this.mapStore.Count); }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayType
+        {
+            get { return this.DebuggerDisplayShortValue; }
+        }
+
+        /// <summary>
+        /// All keys or all values shown as key-value list. List keys are consecutive numbers
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public PropertyNameAndValue[] Values
+        {
+            get
+            {
+                this.InitValues();
+
+                return this.values;
+            }
+        }
+
+        /// <summary>
+        /// Map entries count
+        /// </summary>
+        public int length
+        {
+            get { return this.mapStore.Count; }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/ObjectInstanceDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/ObjectInstanceDebugView.cs
@@ -1,0 +1,50 @@
+﻿using System.Diagnostics;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for ObjectInstance and some classes inheriting ObjectInstance.
+    /// </summary>
+    public class ObjectInstanceDebugView
+    {
+        /// <summary>
+        /// The displayed object
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected ObjectInstance objectInstance;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="objectInstance"></param>
+        public ObjectInstanceDebugView(ObjectInstance objectInstance)
+        {
+            this.objectInstance = objectInstance;
+        }
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.objectInstance.Prototype;
+            }
+        }
+
+        /// <summary>
+        /// Object properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.objectInstance.Properties.ToArray();
+            }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/PromiseInstanceDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/PromiseInstanceDebugView.cs
@@ -1,0 +1,66 @@
+﻿using System.Diagnostics;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for PromiseInstance.
+    /// </summary>
+    public class PromiseInstanceDebugView
+    {
+        /// <summary>
+        /// The displayed PromiseInstance
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected PromiseInstance promiseInstance;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="promiseInstance">The displayed PromiseInstance</param>
+        public PromiseInstanceDebugView(PromiseInstance promiseInstance)
+        {
+            this.promiseInstance = promiseInstance;
+        }
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.promiseInstance.Prototype;
+            }
+        }
+
+        /// <summary>
+        /// PromiseInstance properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.promiseInstance.Properties.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Gets the status
+        /// </summary>
+        public string PromiseStatus
+        {
+            get { return this.promiseInstance.State.ToString(); }
+        }
+
+        /// <summary>
+        /// Gets the value
+        /// </summary>
+        public object PromiseValue
+        {
+            get { return this.promiseInstance.Result; }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/SetEntriesDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/SetEntriesDebugView.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for SetInstance entries - key-value pairs.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    public class SetEntriesDebugView : IDebuggerDisplay
+    {
+        /// <summary>
+        /// The SetInstance internal strorage
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private Dictionary<object, LinkedListNode<object>> setStore;
+
+        /// <summary>
+        /// Key-value pairs
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private PropertyNameAndValue[] values;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="setStore">The SetInstance internal strorage</param>
+        public SetEntriesDebugView(Dictionary<object, LinkedListNode<object>> setStore)
+        {
+            this.setStore = setStore;
+        }
+
+        private void InitValues()
+        {
+            if (this.values == null)
+            {
+                this.values = new PropertyNameAndValue[this.setStore.Count];
+                int idx = 0;
+                foreach (LinkedListNode<object> value in this.setStore.Values)
+                {
+                    this.values[idx] = new PropertyNameAndValue(idx++.ToString(CultureInfo.InvariantCulture),
+                        value.Value, PropertyAttributes.FullAccess);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayValue
+        {
+            get
+            {
+                InitValues();
+                IEnumerable<string> strValues =
+                    this.values.Select(pnv => DebuggerDisplayHelper.ShortStringRepresentation(pnv.Value));
+
+                return string.Format("[{0}]", string.Join(", ", strValues));
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayShortValue
+        {
+            get { return string.Format("Array({0})", this.setStore.Count); }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayType
+        {
+            get { return this.DebuggerDisplayShortValue; }
+        }
+
+        /// <summary>
+        /// Gets the key-value pairs
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public PropertyNameAndValue[] Values
+        {
+            get
+            {
+                InitValues();
+
+                return this.values;
+            }
+        }
+
+        /// <summary>
+        /// Gets the set entries count
+        /// </summary>
+        public int length
+        {
+            get { return this.setStore.Count; }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/SetInstanceDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/SetInstanceDebugView.cs
@@ -1,0 +1,78 @@
+﻿using System.Diagnostics;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for SetInstance
+    /// </summary>
+    public class SetInstanceDebugView
+    {
+        /// <summary>
+        /// The displayed SetInstance
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private SetInstance setInstance;
+
+        /// <summary>
+        /// Debugger for key-value entries
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected SetEntriesDebugView setEntries;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="setInstance">The displayed SetInstance</param>
+        internal SetInstanceDebugView(SetInstance setInstance)
+        {
+            this.setInstance = setInstance;
+        }
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.setInstance.Prototype;
+            }
+        }
+
+        /// <summary>
+        /// Set properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.setInstance.Properties.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Gets key-value entries
+        /// </summary>
+        public SetEntriesDebugView Entries
+        {
+            get
+            {
+                if (this.setEntries == null)
+                    this.setEntries = new SetEntriesDebugView(this.setInstance.Store);
+
+                return this.setEntries;
+            }
+        }
+
+        /// <summary>
+        /// Gets the Set entries count
+        /// </summary>
+        public int size
+        {
+            get { return this.setInstance.Store.Count; }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/SetIteratorDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/SetIteratorDebugView.cs
@@ -1,0 +1,94 @@
+﻿using System.Diagnostics;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for SetIterator
+    /// </summary>
+    public class SetIteratorDebugView
+    {
+        /// <summary>
+        /// The displayed SetIterator
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private SetIterator setIterator;
+
+        /// <summary>
+        /// Debugger for Set key-value entries
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected SetEntriesDebugView iteratorEntries;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="setIterator">The displayed SetIterator</param>
+        internal SetIteratorDebugView(SetIterator setIterator)
+        {
+            this.setIterator = setIterator;
+        }
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.setIterator.Prototype;
+            }
+        }
+
+        /// <summary>
+        /// SetIterator properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.setIterator.Properties.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Get if iterator hs more to iterate
+        /// </summary>
+        public bool IteratorHasMore
+        {
+            get { return !this.setIterator.Done; }
+        }
+
+        /// <summary>
+        /// Get the iterator index
+        /// </summary>
+        public int IteratorIndex
+        {
+            get { return this.setIterator.IteratorIndex; }
+        }
+
+        /// <summary>
+        /// Gets the iterator king - key, value or both
+        /// </summary>
+        public string IteratorKind
+        {
+            get { return this.setIterator.IteratorKind.ToString(); }
+        }
+
+        /// <summary>
+        /// Gets the debugger decorator for Set entries
+        /// </summary>
+        public SetEntriesDebugView Entries
+        {
+            get
+            {
+                if (this.iteratorEntries == null)
+                    this.iteratorEntries = new SetEntriesDebugView(this.setIterator.Set.Store);
+
+                return this.iteratorEntries;
+            }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/StringIteratorDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/StringIteratorDebugView.cs
@@ -1,0 +1,66 @@
+﻿using System.Diagnostics;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for StringIterator
+    /// </summary>
+    public class StringIteratorDebugView
+    {
+        /// <summary>
+        /// The displayed stringIterator
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private StringIterator stringIterator;
+
+        /// <summary>
+        /// Contructor
+        /// </summary>
+        /// <param name="stringIterator">The displayed stringIterator</param>
+        internal StringIteratorDebugView(StringIterator stringIterator)
+        {
+            this.stringIterator = stringIterator;
+        }
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.stringIterator.Prototype;
+            }
+        }
+
+        /// <summary>
+        /// StringIterator properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.stringIterator.Properties.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Gets if iterator hs more to iterate
+        /// </summary>
+        public bool IteratorHasMore
+        {
+            get { return !this.stringIterator.Done; }
+        }
+
+        /// <summary>
+        /// Gets the iterator index
+        /// </summary>
+        public int IteratorIndex
+        {
+            get { return this.stringIterator.IteratorIndex; }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/TypedArrayInstanceDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/TypedArrayInstanceDebugView.cs
@@ -1,0 +1,119 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for TypedArrayInstance
+    /// </summary>
+    public class TypedArrayInstanceDebugView
+    {
+        /// <summary>
+        /// The displayed TypedArrayInstance
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected TypedArrayInstance typedArrayInstance;
+
+        /// <summary>
+        /// All values
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private PropertyNameAndValue[] values;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="typedArrayInstance">The displayed TypedArrayInstance</param>
+        public TypedArrayInstanceDebugView(TypedArrayInstance typedArrayInstance)
+        {
+            this.typedArrayInstance = typedArrayInstance;
+        }
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.typedArrayInstance.Prototype;
+            }
+        }
+
+        /// <summary>
+        /// TypedArrayInstance properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.typedArrayInstance.Properties.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Gets the internal buffer
+        /// </summary>
+        public ArrayBufferInstance buffer
+        {
+            get { return this.typedArrayInstance.Buffer; }
+        }
+
+        /// <summary>
+        /// Gets the klength in bytes
+        /// </summary>
+        public int byteLength
+        {
+            get { return this.typedArrayInstance.Buffer.Buffer.Length; }
+        }
+
+        /// <summary>
+        /// Gets the buffer offset
+        /// </summary>
+        public int byteOffset
+        {
+            get { return this.typedArrayInstance.ByteOffset; }
+        }
+
+        /// <summary>
+        /// Gets length of array in elements
+        /// </summary>
+        public int length
+        {
+            get { return this.typedArrayInstance.Length; }
+        }
+
+        /// <summary>
+        /// Gets the number of bytes per element
+        /// </summary>
+        public int BytesPerElement
+        {
+            get { return this.typedArrayInstance.BytesPerElement; }
+        }
+
+        /// <summary>
+        /// Gets the array elements
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public PropertyNameAndValue[] Values
+        {
+            get
+            {
+                if (this.values == null)
+                {
+                    this.values = new PropertyNameAndValue[this.length];
+                    for (int i = 0; i < this.length; i++)
+                    {
+                        this.values[i] = new PropertyNameAndValue(i.ToString(CultureInfo.InvariantCulture),
+                            this.typedArrayInstance[i], PropertyAttributes.FullAccess);
+                    }
+                }
+
+                return this.values;
+            }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/UserDefinedFunctionDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/UserDefinedFunctionDebugView.cs
@@ -1,0 +1,73 @@
+﻿using Jurassic.Compiler;
+using System.Diagnostics;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for ArrayInstance.
+    /// </summary>
+    public class UserDefinedFunctionDebugView
+    {
+        /// <summary>
+        /// The watched function
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected UserDefinedFunction userDefinedFunction;
+
+        /// <summary>
+        /// Costructor
+        /// </summary>
+        /// <param name="userDefinedFunction">The watched function</param>
+        public UserDefinedFunctionDebugView(UserDefinedFunction userDefinedFunction)
+        {
+            this.userDefinedFunction = userDefinedFunction;
+        }
+
+        /// <summary>
+        /// Parent scope of the function
+        /// </summary>
+        public Scope Closure
+        {
+            get
+            {
+                return this.userDefinedFunction.ParentScope;
+            }
+        }
+
+        /// <summary>
+        /// Local scope of the function
+        /// </summary>
+        public DeclarativeScope LocalScope
+        {
+            get
+            {
+                return this.userDefinedFunction.Scope;
+            }
+        }
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.userDefinedFunction.Prototype;
+            }
+        }
+
+        /// <summary>
+        /// Array properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.userDefinedFunction.Properties.ToArray();
+            }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/WeakMapEntriesDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/WeakMapEntriesDebugView.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for WeakMapInstance entries
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    public class WeakMapEntriesDebugView : IDebuggerDisplay
+    {
+        /// <summary>
+        /// The WeakMapInstance internal storage
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private ConditionalWeakTable<ObjectInstance, object> weakMapStore;
+
+        /// <summary>
+        /// The WeakMapInstance internal storage keys
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IEnumerable<ObjectInstance> keys;
+
+        /// <summary>
+        /// The WeakMapInstance entries debugger decorator
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private WeakMapEntryDebugView[] entries;
+
+        /// <summary>
+        /// The WeakMapInstance entries count
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private int entriesCount;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="weakMapStore">The WeakMapInstance internal storage</param>
+        public WeakMapEntriesDebugView(ConditionalWeakTable<ObjectInstance, object> weakMapStore)
+        {
+            this.weakMapStore = weakMapStore;
+
+            this.keys = this.weakMapStore.GetKeys();
+            this.entriesCount = this.keys.Count();
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayValue
+        {
+            get
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.Append("[");
+                DebuggerDisplayHelper.WeakMapRepresentation(sb, this.weakMapStore);
+                sb.Append("]");
+                return sb.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayShortValue
+        {
+            get { return string.Format("Array({0})", this.entriesCount); }
+        }
+
+        /// <summary>
+        /// Gets the key-value pairs
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayType
+        {
+            get { return this.DebuggerDisplayShortValue; }
+        }
+
+        /// <summary>
+        /// Gets the WeakMapInstance entries debugger decorator
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public WeakMapEntryDebugView[] Entries
+        {
+            get
+            {
+                if (this.entries == null)
+                {
+                    this.entries = new WeakMapEntryDebugView[this.entriesCount];
+                    int idx = 0;
+                    foreach (ObjectInstance key in this.keys)
+                    {
+                        object value;
+                        if (this.weakMapStore.TryGetValue(key, out value))
+                        {
+                            this.entries[idx++] = new WeakMapEntryDebugView(key, value);
+                        }
+                    }
+                }
+
+                return this.entries;
+            }
+        }
+
+        /// <summary>
+        /// Gets the WeakMapInstance entries count
+        /// </summary>
+        public int length
+        {
+            get { return this.entriesCount; }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/WeakMapEntryDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/WeakMapEntryDebugView.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for WeakMapInstance entry - key-value pair
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    public class WeakMapEntryDebugView : IDebuggerDisplay
+    {
+        /// <summary>
+        /// The key
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private ObjectInstance key;
+
+        /// <summary>
+        /// The value
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private object value;
+
+        /// <summary>
+        /// The key-value pair
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private PropertyNameAndValue[] keyAndValue;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="key">The key as JS Object</param>
+        /// <param name="value">The value</param>
+        public WeakMapEntryDebugView(ObjectInstance key, object value)
+        {
+            this.key = key;
+            this.value = value;
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayValue
+        {
+            get
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.Append("{");
+                sb.AppendFormat("{0} => {1}",
+                    DebuggerDisplayHelper.ShortStringRepresentation(this.key),
+                    DebuggerDisplayHelper.ShortStringRepresentation(this.value));
+                sb.Append("}");
+                return sb.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets the key-value pairs
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayType
+        {
+            get { return "WeakMap Entry"; }
+        }
+
+        /// <summary>
+        /// Gets the key and value as Array
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public PropertyNameAndValue[] KeyAndValue
+        {
+            get
+            {
+                if (this.keyAndValue == null)
+                {
+                    this.keyAndValue = new PropertyNameAndValue[2];
+                    this.keyAndValue[0] = new PropertyNameAndValue("key", this.key, PropertyAttributes.FullAccess);
+                    this.keyAndValue[1] = new PropertyNameAndValue("value", this.value, PropertyAttributes.FullAccess);
+                }
+
+                return this.keyAndValue;
+            }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/WeakMapInstanceDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/WeakMapInstanceDebugView.cs
@@ -1,0 +1,70 @@
+﻿using System.Diagnostics;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for WeakMapInstance entry
+    /// </summary>
+    public class WeakMapInstanceDebugView
+    {
+        /// <summary>
+        /// The displayed WeakMapInstance
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected WeakMapInstance weakMapInstance;
+
+        /// <summary>
+        /// The WeakMapInstance entries debugger decorator
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected WeakMapEntriesDebugView mapEntries;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="weakMapInstance">The displayed WeakMapInstance</param>
+        public WeakMapInstanceDebugView(WeakMapInstance weakMapInstance)
+        {
+            this.weakMapInstance = weakMapInstance;
+        }
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.weakMapInstance.Prototype;
+            }
+        }
+
+        /// <summary>
+        /// WeakMapInstance properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.weakMapInstance.Properties.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Gets the WeakMapInstance entries debugger decorator
+        /// </summary>
+        public WeakMapEntriesDebugView Entries
+        {
+            get
+            {
+                if (this.mapEntries == null)
+                    this.mapEntries = new WeakMapEntriesDebugView(this.weakMapInstance.Store);
+
+                return this.mapEntries;
+            }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/WeakSetEntriesDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/WeakSetEntriesDebugView.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for WeakSetInstance entries
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    public class WeakSetEntriesDebugView : IDebuggerDisplay
+    {
+        /// <summary>
+        /// The WeakSetInstance internal storage
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private ConditionalWeakTable<ObjectInstance, object> weakSetStore;
+
+        /// <summary>
+        /// The WeakSetInstance internal storage keys
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private IEnumerable<ObjectInstance> keys;
+
+        /// <summary>
+        /// The WeakSetInstance entries count
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private int entriesCount;
+
+        /// <summary>
+        /// The WeakSetInstance values Array
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private PropertyNameAndValue[] values;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="weakSetStore">The WeakSetInstance internal storage</param>
+        public WeakSetEntriesDebugView(ConditionalWeakTable<ObjectInstance, object> weakSetStore)
+        {
+            this.weakSetStore = weakSetStore;
+
+            this.keys = weakSetStore.GetKeys();
+            this.entriesCount = this.keys.Count();
+        }
+
+        private void InitValues()
+        {
+            if (this.values == null)
+            {
+                this.values = new PropertyNameAndValue[this.entriesCount];
+                int idx = 0;
+                foreach (ObjectInstance key in keys)
+                {
+                    object dummyValue;
+                    if (this.weakSetStore.TryGetValue(key, out dummyValue))
+                    {
+                        this.values[idx] = new PropertyNameAndValue(idx++.ToString(CultureInfo.InvariantCulture),
+                            key, PropertyAttributes.FullAccess);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayValue
+        {
+            get
+            {
+                InitValues();
+                IEnumerable<string> strValues =
+                    this.values.Select(pnv => DebuggerDisplayHelper.ShortStringRepresentation(pnv.Value));
+
+                return string.Format("[{0}]", string.Join(", ", strValues));
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayShortValue
+        {
+            get { return string.Format("Array({0})", this.entriesCount); }
+        }
+
+        /// <summary>
+        /// Gets the key-value pairs
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayType
+        {
+            get { return this.DebuggerDisplayShortValue; }
+        }
+
+        /// <summary>
+        /// Gets the WeakSetInstance values
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public PropertyNameAndValue[] Values
+        {
+            get
+            {
+                InitValues();
+
+                return this.values;
+            }
+        }
+
+        /// <summary>
+        /// Gets the WeakSetInstance elements count
+        /// </summary>
+        public int length
+        {
+            get { return this.entriesCount; }
+        }
+    }
+}

--- a/Jurassic/Library/DebuggerDisplay/WeakSetInstanceDebugView.cs
+++ b/Jurassic/Library/DebuggerDisplay/WeakSetInstanceDebugView.cs
@@ -1,0 +1,70 @@
+﻿using System.Diagnostics;
+using System.Linq;
+
+
+namespace Jurassic.Library
+{
+    /// <summary>
+    /// Debugger decorator for WeakSetInstance
+    /// </summary>
+    public class WeakSetInstanceDebugView
+    {
+        /// <summary>
+        /// The displayed WeakSetInstance
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private WeakSetInstance weakSetInstance;
+
+        /// <summary>
+        /// The debugger decorator for WeakSetInstance entries
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        protected WeakSetEntriesDebugView setEntries;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="weakSetInstance">The displayed WeakSetInstance</param>
+        internal WeakSetInstanceDebugView(WeakSetInstance weakSetInstance)
+        {
+            this.weakSetInstance = weakSetInstance;
+        }
+
+        /// <summary>
+        /// The prototype reference
+        /// </summary>
+        public ObjectInstance __proto__
+        {
+            get
+            {
+                return this.weakSetInstance.Prototype;
+            }
+        }
+
+        /// <summary>
+        /// WeakSetInstance properties list
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Properties
+        {
+            get
+            {
+                return this.weakSetInstance.Properties.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Gets the debugger decorator for WeakSetInstance entries
+        /// </summary>
+        public WeakSetEntriesDebugView Entries
+        {
+            get
+            {
+                if (this.setEntries == null)
+                    this.setEntries = new WeakSetEntriesDebugView(this.weakSetInstance.Store);
+
+                return this.setEntries;
+            }
+        }
+    }
+}

--- a/Jurassic/Library/Error/ErrorInstance.cs
+++ b/Jurassic/Library/Error/ErrorInstance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 
 namespace Jurassic.Library
@@ -7,6 +8,8 @@ namespace Jurassic.Library
     /// <summary>
     /// Represents the base class of all the javascript errors.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public partial class ErrorInstance : ObjectInstance
     {
 
@@ -138,6 +141,34 @@ namespace Jurassic.Library
             if (string.IsNullOrEmpty(message))
                 return name;
             return string.Format("{0}: {1}", name, message);
+        }
+
+        /// <summary>
+        /// Gets an enumerable list of every property name and value associated with this object.
+        /// Does not include properties in the prototype chain.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return this.Message; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "Error"; }
         }
     }
 }

--- a/Jurassic/Library/FirebugConsole/FirebugConsole.cs
+++ b/Jurassic/Library/FirebugConsole/FirebugConsole.cs
@@ -10,6 +10,8 @@ namespace Jurassic.Library
     /// non-standard - it is based on the Firebug console API
     /// (http://getfirebug.com/wiki/index.php/Console_API).
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public partial class FirebugConsole : ObjectInstance
     {
         private IFirebugConsoleOutput output;
@@ -43,6 +45,34 @@ namespace Jurassic.Library
                     throw new ArgumentNullException(nameof(value));
                 this.output = value;
             }
+        }
+
+        /// <summary>
+        /// Gets an enumerable list of every property name and value associated with this object.
+        /// Does not include properties in the prototype chain.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return "Firebug Console"; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "Console"; }
         }
 
 

--- a/Jurassic/Library/Function/ArgumentsInstance.cs
+++ b/Jurassic/Library/Function/ArgumentsInstance.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
 using Jurassic.Compiler;
 
 namespace Jurassic.Library
@@ -7,6 +10,8 @@ namespace Jurassic.Library
     /// <summary>
     /// Represents an arguments object.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public class ArgumentsInstance : ObjectInstance
     {
         private UserDefinedFunction callee;
@@ -159,6 +164,63 @@ namespace Jurassic.Library
 
             // Delegate to the base class implementation.
             return base.Delete(index, throwOnError);
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.Append("[");
+
+                bool comma = false;
+                int len = (int)this["length"];
+                for (int i = 0; i < len; i++)
+                {
+                    object arg = this[i.ToString(CultureInfo.InvariantCulture)];
+                    object value;
+                    if (arg is PropertyAccessorValue)
+                    {
+                        value = (arg as PropertyAccessorValue).GetValue(this);
+                    }
+                    else
+                    {
+                        value = arg;
+                    }
+
+                    if (comma)
+                    {
+                        sb.Append(", ");
+                    }
+                    sb.Append(DebuggerDisplayHelper.ShortStringRepresentation(value));
+                    comma = true;
+                }
+
+                sb.Append("]");
+                return sb.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayType; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return string.Format("Arguments({0})", this["length"]); }
         }
     }
 }

--- a/Jurassic/Library/Function/FunctionInstance.cs
+++ b/Jurassic/Library/Function/FunctionInstance.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// Represents a JavaScript function.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public abstract partial class FunctionInstance : ObjectInstance
     {
         // Used to speed up access to the prototype property.
@@ -119,6 +122,39 @@ namespace Jurassic.Library
             protected set { this.FastSetProperty("length", value); }
         }
 
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get
+            {
+                string name = this.Name;
+                if (string.IsNullOrEmpty(name))
+                    name = "function";
+                string result = string.Format("{0}()", name);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "Function"; }
+        }
 
 
         //     JAVASCRIPT INTERNAL FUNCTIONS

--- a/Jurassic/Library/GlobalObject.cs
+++ b/Jurassic/Library/GlobalObject.cs
@@ -1,6 +1,7 @@
 ﻿using Jurassic.Compiler;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 
 namespace Jurassic.Library
@@ -8,6 +9,8 @@ namespace Jurassic.Library
     /// <summary>
     /// Represents functions and properties within the global scope.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public partial class GlobalObject : ObjectInstance
     {
 

--- a/Jurassic/Library/JSON/JSONObject.cs
+++ b/Jurassic/Library/JSON/JSONObject.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// Represents the built-in JSON object.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public partial class JSONObject : ObjectInstance
     {
 
@@ -87,6 +90,16 @@ namespace Jurassic.Library
 
             // Serialize the value.
             return serializer.Serialize(value);
+        }
+
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "JSON Object"; }
         }
     }
 }

--- a/Jurassic/Library/Map/MapInstance.cs
+++ b/Jurassic/Library/Map/MapInstance.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
 
 namespace Jurassic.Library
 {
@@ -7,6 +9,8 @@ namespace Jurassic.Library
     /// The Map object is a simple key/value map. Any value (both objects and primitive values) may
     /// be used as either a key or a value.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(MapInstanceDebugView))]
     public partial class MapInstance : ObjectInstance
     {
         private readonly Dictionary<object, LinkedListNode<KeyValuePair<object, object>>> store;
@@ -60,6 +64,43 @@ namespace Jurassic.Library
         /// </summary>
         internal event Action<LinkedListNode<KeyValuePair<object, object>>> BeforeDelete;
 
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get
+            {
+                return string.Format("{{{0}}}]", DebuggerDisplayHelper.MapRepresentation(this.store));
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return string.Format("Map({0})", this.store.Count); }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return this.DebuggerDisplayShortValue; }
+        }
+
+        /// <summary>
+        /// Gets the internal storage. Used by debugger decoration only.
+        /// </summary>
+        internal Dictionary<object, LinkedListNode<KeyValuePair<object, object>>> Store
+        {
+            get { return this.store; }
+        }
 
 
         //     JAVASCRIPT PROPERTIES

--- a/Jurassic/Library/Map/MapIterator.cs
+++ b/Jurassic/Library/Map/MapIterator.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// Represents an iteration over a Map.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(MapIteratorDebugView))]
     internal partial class MapIterator : ObjectInstance
     {
         private MapInstance map;
@@ -135,6 +138,75 @@ namespace Jurassic.Library
                     new PropertyNameAndValue("done", this.done, PropertyAttributes.FullAccess),
                 });
             return result;
+        }
+
+
+
+        //     .NET PROPERTIES
+        //_________________________________________________________________________________________
+
+        /// <summary>
+        /// Gets wheter the end is reached. Used by debugger decoration only.
+        /// </summary>
+        internal bool Done
+        {
+            get { return this.done; }
+        }
+
+        /// <summary>
+        /// Gets current index. Used by debugger decoration only.
+        /// </summary>
+        internal int IteratorIndex
+        {
+            get
+            {
+                return this.lastNode == null
+                    ? 0
+                    : new List<KeyValuePair<object, object>>(this.list).IndexOf(this.lastNode.Value) + 1;
+            }
+        }
+
+        /// <summary>
+        /// Gets what is iterated - key, value or both
+        /// </summary>
+        internal Kind IteratorKind
+        {
+            get { return this.kind; }
+        }
+
+        /// <summary>
+        /// Gets the iterated Map
+        /// </summary>
+        internal MapInstance Map
+        {
+            get { return this.map; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return this.kind.ToString(); }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return this.ToStringTag; }
         }
     }
 }

--- a/Jurassic/Library/MathObject.cs
+++ b/Jurassic/Library/MathObject.cs
@@ -1,10 +1,13 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// Represents the built-in Math class that has mathematical constants and functions.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public partial class MathObject : ObjectInstance
     {
 

--- a/Jurassic/Library/Number/NumberInstance.cs
+++ b/Jurassic/Library/Number/NumberInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 
 namespace Jurassic.Library
@@ -10,6 +11,8 @@ namespace Jurassic.Library
     /// None of the methods of the Number prototype are generic; they should throw <c>TypeError</c>
     /// if the <c>this</c> value is not a Number object or a number primitive.
     /// </remarks>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public partial class NumberInstance : ObjectInstance
     {
         /// <summary>
@@ -57,6 +60,36 @@ namespace Jurassic.Library
         public double Value
         {
             get { return this.value; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get
+            {
+                return this.Value.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "Number"; }
         }
 
 

--- a/Jurassic/Library/Object/ObjectInstance.cs
+++ b/Jurassic/Library/Object/ObjectInstance.cs
@@ -3,16 +3,21 @@ using System.Collections.Generic;
 using System.Reflection;
 using Jurassic.Compiler;
 using System.Linq;
+using System.Diagnostics;
+using System.Text;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// Provides functionality common to all JavaScript objects.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public partial class ObjectInstance
     {
         // The script engine associated with this object.
         [NonSerialized]
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private ScriptEngine engine;
 
         // Internal prototype chain.
@@ -118,6 +123,7 @@ namespace Jurassic.Library
         /// <summary>
         /// Gets a reference to the script engine associated with this object.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public ScriptEngine Engine
         {
             get { return this.engine; }
@@ -204,6 +210,40 @@ namespace Jurassic.Library
             }
         }
         
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public virtual string DebuggerDisplayValue
+        {
+            get
+            {
+                IEnumerable<string> strValues =
+                    this.Properties.Select(pnv => 
+                        string.Format("{0}: {1}", pnv.Key, DebuggerDisplayHelper.ShortStringRepresentation(pnv.Value)));
+
+                return string.Format("{{{0}}}", string.Join(", ", strValues));
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public virtual string DebuggerDisplayShortValue
+        {
+            get { return "{\u2026}"; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public virtual string DebuggerDisplayType
+        {
+            get { return "Object"; }
+        }
+
 
 
         //     PROPERTY MANAGEMENT

--- a/Jurassic/Library/Object/PropertyAccessorValue.cs
+++ b/Jurassic/Library/Object/PropertyAccessorValue.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Jurassic.Library
 {
@@ -7,7 +8,8 @@ namespace Jurassic.Library
     /// <summary>
     /// Represents a the value of an accessor property.
     /// </summary>
-    internal sealed class PropertyAccessorValue
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    internal sealed class PropertyAccessorValue : IDebuggerDisplay
     {
         private FunctionInstance getter;
         private FunctionInstance setter;
@@ -61,6 +63,49 @@ namespace Jurassic.Library
             if (this.setter == null)
                 return;
             this.setter.CallLateBound(thisObject, value);
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayValue
+        {
+            get
+            {
+                string result = string.Empty;
+                if (this.getter != null && this.setter != null)
+                {
+                    result = "getter;setter";
+                }
+                else if (this.getter != null)
+                {
+                    result = "getter";
+                }
+                else if (this.setter != null)
+                {
+                    result = "getter";
+                }
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayType
+        {
+            get { return "Property Accessor"; }
         }
     }
 

--- a/Jurassic/Library/Object/PropertyNameAndValue.cs
+++ b/Jurassic/Library/Object/PropertyNameAndValue.cs
@@ -1,11 +1,21 @@
-﻿namespace Jurassic.Library
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+
+
+namespace Jurassic.Library
 {
     /// <summary>
     /// Represents a property name and value.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Name = "{Key,nq}", Type = "{DebuggerDisplayType,nq}")]
     public sealed class PropertyNameAndValue
     {
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private object key;
+
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private PropertyDescriptor descriptor;
 
         /// <summary>
@@ -47,6 +57,7 @@
         /// <summary>
         /// Gets the property key.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public object Key
         {
             get { return this.key; }
@@ -55,15 +66,72 @@
         /// <summary>
         /// Gets the value of the property.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         public object Value
         {
             get { return this.descriptor.Value; }
         }
 
         /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayValue
+        {
+            get
+            {
+                string result;
+                if (this.descriptor.Value is ObjectInstance)
+                {
+                    result = (this.descriptor.Value as ObjectInstance).DebuggerDisplayValue;
+                }
+                else if (this.descriptor.Value is string)
+                {
+                    result = string.Format("\"{0}\"", this.descriptor.Value);
+                }
+                else
+                {
+                    IFormattable formattable = this.descriptor.Value as IFormattable;
+                    if (formattable == null)
+                    {
+                        result = this.descriptor.Value.ToString();
+                    }
+                    else
+                    {
+                        result = formattable.ToString(null, CultureInfo.InvariantCulture);
+                    }
+                }
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayType
+        {
+            get
+            {
+                string result;
+                if (this.descriptor.Value is ObjectInstance)
+                {
+                    result = (this.descriptor.Value as ObjectInstance).DebuggerDisplayType;
+                }
+                else
+                {
+                    result = this.descriptor.Value?.GetType().Name;
+                }
+                return result;
+            }
+        }
+
+
+        /// <summary>
         /// Gets the property attributes.  These attributes describe how the property can
         /// be modified.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public PropertyAttributes Attributes
         {
             get { return this.descriptor.Attributes; }
@@ -72,6 +140,7 @@
         /// <summary>
         /// Gets a boolean value indicating whether the property value can be set.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public bool IsWritable
         {
             get { return this.descriptor.IsWritable; }
@@ -81,6 +150,7 @@
         /// Gets a boolean value indicating whether the property value will be included during an
         /// enumeration.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public bool IsEnumerable
         {
             get { return this.descriptor.IsEnumerable; }
@@ -89,6 +159,7 @@
         /// <summary>
         /// Gets a boolean value indicating whether the property can be deleted.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public bool IsConfigurable
         {
             get { return this.descriptor.IsConfigurable; }

--- a/Jurassic/Library/Object/PropertyReference.cs
+++ b/Jurassic/Library/Object/PropertyReference.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace Jurassic.Library
 {
@@ -6,8 +7,10 @@ namespace Jurassic.Library
     /// <summary>
     /// Represents a property name. Used to speed up access to object properties and global variables.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Name = "{Name,nq}", Type = "{DebuggerDisplayType,nq}")]
     public sealed class PropertyReference
     {
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private string propertyName;
 
         /// <summary>
@@ -24,6 +27,7 @@ namespace Jurassic.Library
         /// <summary>
         /// The property name.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public string Name
         {
             get { return propertyName; }
@@ -32,11 +36,13 @@ namespace Jurassic.Library
         /// <summary>
         /// A reference to a schema that defines how properties are stored.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         internal HiddenClassSchema CachedSchema { get; private set; }
 
         /// <summary>
         /// The index into the property array.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         internal int CachedIndex { get; private set; }
 
         /// <summary>
@@ -56,6 +62,30 @@ namespace Jurassic.Library
         internal void ClearCache()
         {
             this.CachedSchema = null;
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayValue
+        {
+            get
+            {
+                return Name;
+            }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string DebuggerDisplayType
+        {
+            get
+            {
+                return Name;
+            }
         }
 
         /// <summary>

--- a/Jurassic/Library/Promise/PromiseInstance.cs
+++ b/Jurassic/Library/Promise/PromiseInstance.cs
@@ -1,11 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// Represents an instance of the Promise object.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(PromiseInstanceDebugView))]
     public partial class PromiseInstance : ObjectInstance
     {
         internal enum PromiseState
@@ -40,10 +44,20 @@ namespace Jurassic.Library
         {
             FunctionInstance resolveFunc = new ClrStubFunction(Engine.FunctionInstancePrototype, (engine, thisObj, param) =>
             {
+                this.state = PromiseState.Fulfilled;
+                if (param.Length > 0)
+                {
+                    result = param[0];
+                }
                 return Undefined.Value;
             });
             FunctionInstance rejectFunc = new ClrStubFunction(Engine.FunctionInstancePrototype, (engine, thisObj, param) =>
             {
+                this.state = PromiseState.Rejected;
+                if (param.Length > 0)
+                {
+                    result = param[0];
+                }
                 return Undefined.Value;
             });
             try
@@ -102,6 +116,57 @@ namespace Jurassic.Library
         public PromiseInstance Then(FunctionInstance onFulfilled, FunctionInstance onRejected)
         {
             throw new NotImplementedException();
+        }
+
+
+
+        //     .NET ACCESSOR PROPERTIES
+        //_________________________________________________________________________________________
+
+        /// <summary>
+        /// Gets the promise status. Used by debugger decoration only.
+        /// </summary>
+        internal PromiseState State
+        {
+            get { return this.state; }
+        }
+
+        /// <summary>
+        /// Gets the promise result. Used by debugger decoration only.
+        /// </summary>
+        internal object Result
+        {
+            get { return this.result; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get
+            {
+                return this.state.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "Promise"; }
         }
     }
 }

--- a/Jurassic/Library/RegExp/RegExpInstance.cs
+++ b/Jurassic/Library/RegExp/RegExpInstance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 namespace Jurassic.Library
@@ -7,6 +8,8 @@ namespace Jurassic.Library
     /// <summary>
     /// Represents an instance of the RegExp object.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public partial class RegExpInstance : ObjectInstance
     {
         private Regex value;
@@ -89,6 +92,33 @@ namespace Jurassic.Library
         public Regex Value
         {
             get { return this.value; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return this.Value.ToString(); }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "RegExp"; }
         }
 
 

--- a/Jurassic/Library/Set/SetInstance.cs
+++ b/Jurassic/Library/Set/SetInstance.cs
@@ -1,11 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// The Set object lets you store unique values of any type, whether primitive values or object references.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(SetInstanceDebugView))]
     public partial class SetInstance : ObjectInstance
     {
         private readonly Dictionary<object, LinkedListNode<object>> store;
@@ -57,6 +62,51 @@ namespace Jurassic.Library
         /// Called before a linked list node is deleted.
         /// </summary>
         internal event Action<LinkedListNode<object>> BeforeDelete;
+
+        /// <summary>
+        /// Gets the internal storage. Used by debugger decoration only.
+        /// </summary>
+        internal Dictionary<object, LinkedListNode<object>> Store
+        {
+            get { return this.store; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get
+            {
+                IEnumerable<string> strValues =
+                    this.store.Values.Select(value => DebuggerDisplayHelper.ShortStringRepresentation(value.Value));
+
+                return string.Format("[{0}]", string.Join(", ", strValues));
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayType; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get
+            {
+                string result = string.Format("Set({0})", this.store.Count);
+                return result;
+            }
+        }
 
 
         //     JAVASCRIPT PROPERTIES

--- a/Jurassic/Library/Set/SetIterator.cs
+++ b/Jurassic/Library/Set/SetIterator.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// Represents an iteration over a Set.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(SetIteratorDebugView))]
     internal partial class SetIterator : ObjectInstance
     {
         private SetInstance set;
@@ -132,6 +135,75 @@ namespace Jurassic.Library
                     new PropertyNameAndValue("done", this.done, PropertyAttributes.FullAccess),
                 });
             return result;
+        }
+
+
+
+        //     .NET PROPERTIES
+        //_________________________________________________________________________________________
+
+        /// <summary>
+        /// Gets wheter the end is reached. Used by debugger decoration only.
+        /// </summary>
+        internal bool Done
+        {
+            get { return this.done; }
+        }
+
+        /// <summary>
+        /// Gets current index. Used by debugger decoration only.
+        /// </summary>
+        internal int IteratorIndex
+        {
+            get
+            {
+                return this.lastNode == null
+                    ? 0
+                    : new List<object>(this.list).IndexOf(this.lastNode.Value) + 1;
+            }
+        }
+
+        /// <summary>
+        /// Gets what is iterated - key, value or both.
+        /// </summary>
+        internal Kind IteratorKind
+        {
+            get { return this.kind; }
+        }
+
+        /// <summary>
+        /// Gets the iterated Set.
+        /// </summary>
+        internal SetInstance Set
+        {
+            get { return this.set; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return this.kind.ToString(); }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return this.ToStringTag; }
         }
     }
 }

--- a/Jurassic/Library/String/StringInstance.cs
+++ b/Jurassic/Library/String/StringInstance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 
@@ -8,6 +9,8 @@ namespace Jurassic.Library
     /// <summary>
     /// Represents an instance of the JavaScript string object.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public partial class StringInstance : ObjectInstance
     {
         private string value;
@@ -64,6 +67,33 @@ namespace Jurassic.Library
         public int Length
         {
             get { return this.value.Length; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return this.Value; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.Value; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "String Object"; }
         }
 
 

--- a/Jurassic/Library/String/StringIterator.cs
+++ b/Jurassic/Library/String/StringIterator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 
 namespace Jurassic.Library
@@ -7,9 +8,12 @@ namespace Jurassic.Library
     /// <summary>
     /// Represents an iteration over a String.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(StringIteratorDebugView))]
     internal partial class StringIterator : ObjectInstance
     {
         private TextElementEnumerator enumerator;
+        private bool done;
 
 
         //     INITIALIZATION
@@ -65,19 +69,18 @@ namespace Jurassic.Library
         public ObjectInstance Next()
         {
             object value;
-            bool done;
 
             if (this.enumerator.MoveNext())
             {
                 // Return the text element.
                 value = this.enumerator.Current;
-                done = false;
+                this.done = false;
             }
             else
             {
                 // We've reached the end of the string.
                 value = Undefined.Value;
-                done = true;
+                this.done = true;
             }
 
             // Return the result.
@@ -88,6 +91,83 @@ namespace Jurassic.Library
                     new PropertyNameAndValue("done", done, PropertyAttributes.FullAccess),
                 });
             return result;
+        }
+
+
+
+        //     .NET PROPERTIES
+        //_________________________________________________________________________________________
+
+        /// <summary>
+        /// Gets wheter the end is reached. Used by debugger decoration only.
+        /// </summary>
+        internal bool Done
+        {
+            get { return this.done; }
+        }
+
+        /// <summary>
+        /// Gets current index. Used by debugger decoration only.
+        /// </summary>
+        internal int IteratorIndex
+        {
+            get
+            {
+                try
+                {
+                    return this.enumerator.ElementIndex;
+                }
+                catch (Exception)
+                {
+                    return 0;
+                }
+            }
+
+        }
+
+        /// <summary>
+        /// Gets current character. Used by debugger decoration only.
+        /// </summary>
+        public string Current
+        {
+            get
+            {
+                try
+                {
+                    return this.enumerator.Current as string;
+                }
+                catch (Exception)
+                {
+                    return null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return this.Current as string; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return this.ToStringTag; }
         }
     }
 }

--- a/Jurassic/Library/Symbol/SymbolInstance.cs
+++ b/Jurassic/Library/Symbol/SymbolInstance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 
@@ -8,6 +9,8 @@ namespace Jurassic.Library
     /// <summary>
     /// Represents an instance of the Symbol object.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
     public partial class SymbolInstance : ObjectInstance
     {
         private string description;
@@ -76,6 +79,39 @@ namespace Jurassic.Library
         public SymbolInstance ToPrimitive(string hint)
         {
             return this;
+        }
+
+
+
+        //     .NET ACCESSOR PROPERTIES
+        //_________________________________________________________________________________________
+
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return this.ToStringJS(); }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayValue; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return "Symbol"; }
         }
     }
 }

--- a/Jurassic/Library/TypedArray/ArrayBufferInstance.cs
+++ b/Jurassic/Library/TypedArray/ArrayBufferInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace Jurassic.Library
 {
@@ -8,6 +9,8 @@ namespace Jurassic.Library
     /// the typed array objects or a DataView object which represents the buffer in a specific
     /// format, and use that to read and write the contents of the buffer.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(ArrayBufferInstanceDebugView))]
     public partial class ArrayBufferInstance : ObjectInstance
     {
         private byte[] buffer;
@@ -65,6 +68,33 @@ namespace Jurassic.Library
         internal byte[] Buffer
         {
             get { return this.buffer; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return "{}"; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayType; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return string.Format("ArrayBuffer({0})", this.buffer.Length); }
         }
 
 

--- a/Jurassic/Library/TypedArray/DataViewInstance.cs
+++ b/Jurassic/Library/TypedArray/DataViewInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace Jurassic.Library
 {
@@ -6,6 +7,8 @@ namespace Jurassic.Library
     /// The DataView view provides a low-level interface for reading and writing multiple number
     /// types in an ArrayBuffer irrespective of the platform's endianness.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(DataViewInstanceDebugView))]
     public partial class DataViewInstance : ObjectInstance
     {
         private ArrayBufferInstance buffer;
@@ -422,5 +425,37 @@ namespace Jurassic.Library
             }
         }
 
+
+
+        //     .NET PROPERTIES
+        //_________________________________________________________________________________________
+
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get { return "{}"; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayType; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return string.Format("DataView({0})", this.byteLength); }
+        }
     }
 }

--- a/Jurassic/Library/TypedArray/TypedArrayInstance.cs
+++ b/Jurassic/Library/TypedArray/TypedArrayInstance.cs
@@ -1,10 +1,14 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Text;
 
 namespace Jurassic.Library
 {
     /// <summary>
     /// Represents a typed array instance.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(TypedArrayInstanceDebugView))]
     public partial class TypedArrayInstance : ObjectInstance
     {
         private TypedArrayType type;
@@ -177,7 +181,7 @@ namespace Jurassic.Library
         /// <summary>
         /// The data storage size, in bytes, of each array element.
         /// </summary>
-        private int BytesPerElement
+        internal int BytesPerElement
         {
             get
             {
@@ -201,6 +205,51 @@ namespace Jurassic.Library
                 }
             }
         }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.Append("[");
+                bool comma = false;
+                for (int i = 0; i < this.Length; i++)
+                {
+                    if (comma)
+                    {
+                        sb.Append(", ");
+                    }
+                    sb.Append(DebuggerDisplayHelper.ShortStringRepresentation(this[i]));
+                    comma = true;
+                }
+
+                sb.Append("]");
+                return sb.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayType; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return string.Format("{0}({1})", this.Type, this.Length); }
+        }
+
 
 
         //     JAVASCRIPT PROPERTIES

--- a/Jurassic/Library/WeakMap/WeakMapInstance.cs
+++ b/Jurassic/Library/WeakMap/WeakMapInstance.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Jurassic.Library
 {
@@ -8,6 +11,8 @@ namespace Jurassic.Library
     /// The WeakMap object is a collection of key/value pairs in which the keys are weakly
     /// referenced.  The keys must be objects and the values can be arbitrary values.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(WeakMapInstanceDebugView))]
     public partial class WeakMapInstance : ObjectInstance
     {
         private readonly ConditionalWeakTable<ObjectInstance, object> store;
@@ -128,6 +133,54 @@ namespace Jurassic.Library
                 this.store.Add(keyObj, value);
             }
             return this;
+        }
+
+
+
+        //     .NET PROPERTIES
+        //_________________________________________________________________________________________
+
+        
+        /// <summary>
+        /// Gets the internal storage. Used by debugger decoration.
+        /// </summary>
+        internal ConditionalWeakTable<ObjectInstance, object> Store
+        {
+            get { return this.store; }
+        }
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.Append("{");
+                DebuggerDisplayHelper.WeakMapRepresentation(sb, this.store);
+                sb.Append("}");
+                return sb.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayType; }
+        }
+
+        /// <summary>
+        /// Gets the key-value pairs
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get { return string.Format("WeakMap({0})", this.store.GetKeys().Count()); }
         }
     }
 }

--- a/Jurassic/Library/WeakSet/WeakSetInstance.cs
+++ b/Jurassic/Library/WeakSet/WeakSetInstance.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace Jurassic.Library
@@ -7,6 +8,8 @@ namespace Jurassic.Library
     /// <summary>
     /// The WeakSet object lets you store weakly held objects in a collection.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplayValue,nq}", Type = "{DebuggerDisplayType,nq}")]
+    [DebuggerTypeProxy(typeof(WeakSetInstanceDebugView))]
     public partial class WeakSetInstance : ObjectInstance
     {
         private readonly ConditionalWeakTable<ObjectInstance, object> store;
@@ -93,6 +96,59 @@ namespace Jurassic.Library
 
             object result;
             return this.store.TryGetValue(valueObj, out result);
+        }
+
+
+        //     .NET PROPERTIES
+        //_________________________________________________________________________________________
+
+
+        /// <summary>
+        /// Gets the internal storage. Used by debugger decoration.
+        /// </summary>
+        internal ConditionalWeakTable<ObjectInstance, object> Store
+        {
+            get { return this.store; }
+        }
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayValue
+        {
+            get
+            {
+                IEnumerable<ObjectInstance> keys = this.store.GetKeys();
+                IEnumerable<string> strValues =
+                    keys.Select(key => DebuggerDisplayHelper.ShortStringRepresentation(key));
+
+                return string.Format("[{0}]", string.Join(", ", strValues));
+            }
+        }
+
+
+        /// <summary>
+        /// Gets value, that will be displayed in debugger watch window when this object is part of array, map, etc.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayShortValue
+        {
+            get { return this.DebuggerDisplayType; }
+        }
+
+
+        /// <summary>
+        /// Gets type, that will be displayed in debugger watch window.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public override string DebuggerDisplayType
+        {
+            get
+            {
+                string result = string.Format("WeakSet({0})", this.store.GetKeys().Count());
+                return result;
+            }
         }
     }
 }


### PR DESCRIPTION
This code displays JavaScript objects in the Visual Studio Debugger in a JavaScript way. `ObjectInstance` and classes inheriting `ObjectInstance` are decorated.

Visual Studio 2015 and 2017 debugger support inheritance of the `DebuggerDisplayAttribute` and `DebuggerTypeProxy`. For example only `ObjectInstance` can have them and then `FunctionInstance` will be decorated. In former versions this is not supported and `FunctionInstance` will not be decorated. That's why every class which is inheriting `ObjectInstance` has these attributes, even when they are the same with the base class.

Some properties are made internal and some fields are exposed via internal properties to be displayed in debugger.

Changing of values via debugger watch window works. Probably will not work well with some CLR objects. Tested with numbers and strings.

The `PromiseInstance` now keeps state and result to be available in debugger.

The `PropertyReference` displays name as value, because doesn't contain value.
