### PR TITLE
Pull support for Clr indexers and arrays

### DIFF
--- a/Jurassic/Library/ClrWrapper/ClrInstanceTypeWrapper.cs
+++ b/Jurassic/Library/ClrWrapper/ClrInstanceTypeWrapper.cs
@@ -113,6 +113,18 @@ namespace Jurassic.Library
 
 
 
+        //     OBJECTINSTANCE OVERRIDES
+        //_________________________________________________________________________________________
+
+        /// <summary>
+        /// This object is a Clr Wrapper
+        /// </summary>
+        protected override bool IsClrWrapper
+        {
+            get { return true; }
+        }
+
+
 
         //     OBJECT OVERRIDES
         //_________________________________________________________________________________________

--- a/Jurassic/Library/ClrWrapper/ClrInstanceWrapper.cs
+++ b/Jurassic/Library/ClrWrapper/ClrInstanceWrapper.cs
@@ -122,6 +122,13 @@ namespace Jurassic.Library
         //    return base.GetPrimitiveValue(typeHint);
         //}
 
+        /// <summary>
+        /// This object is a Clr Wrapper
+        /// </summary>
+        protected override bool IsClrWrapper
+        {
+            get { return true; }
+        }
 
 
 

--- a/Jurassic/Library/ClrWrapper/ClrStaticTypeWrapper.cs
+++ b/Jurassic/Library/ClrWrapper/ClrStaticTypeWrapper.cs
@@ -265,6 +265,18 @@ namespace Jurassic.Library
 
 
 
+        //     OBJECTINSTANCE OVERRIDES
+        //_________________________________________________________________________________________
+
+        /// <summary>
+        /// This object is a Clr Wrapper
+        /// </summary>
+        protected override bool IsClrWrapper
+        {
+            get { return true; }
+        }
+
+
 
         //     OBJECT OVERRIDES
         //_________________________________________________________________________________________

--- a/Jurassic/Library/ClrWrapper/ClrStaticTypeWrapper.cs
+++ b/Jurassic/Library/ClrWrapper/ClrStaticTypeWrapper.cs
@@ -199,6 +199,7 @@ namespace Jurassic.Library
         {
             // Register static methods as functions.
             var methodGroups = new Dictionary<string, List<MethodBase>>();
+            int indexerCounter = 0;
             foreach (var member in type.GetMembers(BindingFlags.Public | BindingFlags.DeclaredOnly | flags))
             {
                 switch (member.MemberType)
@@ -218,7 +219,17 @@ namespace Jurassic.Library
                         ClrFunction getter = getMethod == null ? null : new ClrFunction(target.Engine.Function.InstancePrototype, new ClrBinder(getMethod));
                         var setMethod = property.GetSetMethod();
                         ClrFunction setter = setMethod == null ? null : new ClrFunction(target.Engine.Function.InstancePrototype, new ClrBinder(setMethod));
-                        target.DefineProperty(property.Name, new PropertyDescriptor(getter, setter, PropertyAttributes.NonEnumerable), false);
+
+                        PropertyAttributes propertyAttributes = PropertyAttributes.NonEnumerable;
+                        if (property.GetIndexParameters().Length > 0)
+                        {
+                            propertyAttributes |= PropertyAttributes.IsIndexProperty;
+                            // Put index after name of indexer property to avoid conflict with other properties with same name and other indexers
+                            target.DefineProperty(string.Format("{0}{1}", property.Name, indexerCounter++), 
+                                new PropertyDescriptor(getter, setter, propertyAttributes), false);
+                        }
+                        else
+                            target.DefineProperty(property.Name, new PropertyDescriptor(getter, setter, propertyAttributes), false);
 
                         // Property getters and setters also show up as methods, so remove them here.
                         // NOTE: only works if properties are enumerated after methods.

--- a/Jurassic/Library/Object/HiddenClassSchema.cs
+++ b/Jurassic/Library/Object/HiddenClassSchema.cs
@@ -14,7 +14,7 @@ namespace Jurassic.Library
         private Dictionary<object, SchemaProperty> properties;
 
         // Transitions
-            private struct TransitionInfo
+        private struct TransitionInfo
         {
             public object Key;
             public PropertyAttributes Attributes;
@@ -122,6 +122,14 @@ namespace Jurassic.Library
             if (this.properties.TryGetValue(key, out propertyInfo) == false)
                 return SchemaProperty.Undefined;
             return propertyInfo;
+        }
+
+        public IEnumerable<SchemaProperty> GetIndexers()
+        {
+            if (this.properties == null)
+                this.properties = CreatePropertiesDictionary();
+            IEnumerable<SchemaProperty> result = this.properties.Values.Where(sp => sp.IsIndexer);
+            return result;
         }
 
         /// <summary>

--- a/Jurassic/Library/Object/ObjectInstance.cs
+++ b/Jurassic/Library/Object/ObjectInstance.cs
@@ -456,6 +456,9 @@ namespace Jurassic.Library
         /// this object. </remarks>
         private object GetIndexerPropertyValue(object key, ObjectInstance thisValue)
         {
+            if (!IsClrWrapper)
+                return null;    // This method is only for CLR clases
+
             ObjectInstance prototypeObject = thisValue;
             do
             {
@@ -491,8 +494,11 @@ namespace Jurassic.Library
         /// <param name="index"> The array index of the property. </param>
         /// <param name="thisValue"> The value of the "this" keyword inside a getter. </param>
         /// <returns> The value of the property, or <c>null</c> if the object is not an Array. </returns>
-        private static object GetArrayElementPropertyValue(uint index, ObjectInstance thisValue)
+        private object GetArrayElementPropertyValue(uint index, ObjectInstance thisValue)
         {
+            if (!IsClrWrapper)
+                return null;   //This method is only for CLR clases
+
             object result = null;
             ClrInstanceWrapper thisWrapper = thisValue as ClrInstanceWrapper;
             if (thisWrapper != null && thisWrapper.WrappedInstance.GetType().IsArray)
@@ -762,6 +768,9 @@ namespace Jurassic.Library
         /// this object. </remarks>
         private bool SetIndexerPropertyValue(object key, object value, ObjectInstance thisValue)
         {
+            if (!IsClrWrapper)
+                return false;   // This method is only for CLR clases
+
             ObjectInstance prototypeObject = thisValue;
             do
             {
@@ -801,6 +810,9 @@ namespace Jurassic.Library
         /// <returns> <c>true</c> if the value is set; <c>false</c> otherwise. </returns>
         private bool SetArrayElementPropertyValue(uint index, ObjectInstance thisValue, object value)
         {
+            if (!IsClrWrapper)
+                return false;   // This method is only for CLR clases
+
             ClrInstanceWrapper thisWrapper = thisValue as ClrInstanceWrapper;
             if (thisWrapper != null && thisWrapper.WrappedInstance.GetType().IsArray)
             {
@@ -1216,6 +1228,14 @@ namespace Jurassic.Library
             {
                 return "<error>";
             }
+        }
+
+        /// <summary>
+        /// Returns true when JavaScript object is a Clr Wrapper
+        /// </summary>
+        protected virtual bool IsClrWrapper
+        {
+            get { return false; }
         }
 
 

--- a/Jurassic/Library/Object/PropertyAccessorValue.cs
+++ b/Jurassic/Library/Object/PropertyAccessorValue.cs
@@ -58,12 +58,12 @@ namespace Jurassic.Library
         /// Sets the property value by calling the setter, if one is present.
         /// </summary>
         /// <param name="thisObject"> The value of the "this" keyword inside the setter. </param>
-        /// <param name="value"> The desired value. </param>
-        public void SetValue(ObjectInstance thisObject, object value)
+        /// <param name="argumentValues"> The values as arguments list. </param>
+        public void SetValue(ObjectInstance thisObject, params object[] argumentValues)
         {
             if (this.setter == null)
                 return;
-            this.setter.CallLateBound(thisObject, value);
+            this.setter.CallLateBound(thisObject, argumentValues);
         }
 
         /// <summary>

--- a/Jurassic/Library/Object/PropertyAccessorValue.cs
+++ b/Jurassic/Library/Object/PropertyAccessorValue.cs
@@ -45,12 +45,13 @@ namespace Jurassic.Library
         /// Gets the property value by calling the getter, if one is present.
         /// </summary>
         /// <param name="thisObject"> The value of the "this" keyword inside the getter. </param>
+        /// <param name="argumentValues"></param>
         /// <returns> The property value returned by the getter. </returns>
-        public object GetValue(ObjectInstance thisObject)
+        public object GetValue(ObjectInstance thisObject, params object[] argumentValues)
         {
             if (this.getter == null)
                 return Undefined.Value;
-            return this.getter.CallLateBound(thisObject);
+            return this.getter.CallLateBound(thisObject, argumentValues);
         }
 
         /// <summary>

--- a/Jurassic/Library/Object/PropertyAttributes.cs
+++ b/Jurassic/Library/Object/PropertyAttributes.cs
@@ -53,5 +53,10 @@ namespace Jurassic.Library
         /// Indicates the property is the "magic" length property (only found on arrays).
         /// </summary>
         IsLengthProperty = 16,
+
+        /// <summary>
+        /// Indicates the property is index property
+        /// </summary>
+        IsIndexProperty = 32,
     }
 }

--- a/Jurassic/Library/Object/SchemaProperty.cs
+++ b/Jurassic/Library/Object/SchemaProperty.cs
@@ -94,6 +94,14 @@ namespace Jurassic.Library
         {
             get { return (this.Attributes & PropertyAttributes.IsLengthProperty) != 0; }
         }
+
+        /// <summary>
+        /// Gets a value that indicates whether the property is indexer property.
+        /// </summary>
+        public bool IsIndexer
+        {
+            get { return (this.Attributes & PropertyAttributes.IsIndexProperty) != 0; }
+        }
     }
 
 }


### PR DESCRIPTION
Added support for Clr indexers and array elements. When property is not found and the object is a Clr Wrapper, a search for indexer is performed.