### PR TITLE
Added a ability to disable exposing of CLR collections by value

### DIFF
--- a/Jurassic/Core/ScriptEngine.cs
+++ b/Jurassic/Core/ScriptEngine.cs
@@ -664,6 +664,22 @@ namespace Jurassic
             set;
         }
 
+        /// <summary>
+        /// Gets or sets a value that indicates whether to disable conversion of CLR collections, that are
+        /// passed or returned to script code, to script arrays (instances of the <see cref="ArrayInstance"/>
+        /// class). If this is set to <c>true</c>, then CLR collections are wrapped in an instances of the
+        /// <see cref="ClrInstanceWrapper"/> class.
+        /// </summary>
+        /// <remarks>
+        /// <para>This property is ignored if value of the <see cref="EnableExposedClrTypes"/> property is
+        /// <c>false</c>.</para>
+        /// </remarks>
+        public bool DisableClrCollectionsExposingByValue
+        {
+            get;
+            set;
+        }
+
 
 
         //     EXECUTION
@@ -1014,7 +1030,7 @@ namespace Jurassic
                         if (value is Type)
                             value = ClrStaticTypeWrapper.FromCache(this, (Type)value);
                         else if ((value is ObjectInstance) == false)
-                            value = new ClrInstanceWrapper(this, value);
+                            value = ClrInstanceWrapper.Create(this, value);
                         break;
                     case TypeCode.SByte:
                         value = (int)(sbyte)value;

--- a/Jurassic/Library/ClrWrapper/ClrInstanceWrapper.cs
+++ b/Jurassic/Library/ClrWrapper/ClrInstanceWrapper.cs
@@ -49,7 +49,7 @@ namespace Jurassic.Library
         /// <param name="instance"> The CLR object instance to wrap. </param>
         public static ObjectInstance Create(ScriptEngine engine, object instance)
         {
-            if (instance is IEnumerable enumerable)
+            if (!engine.DisableClrCollectionsExposingByValue && instance is IEnumerable enumerable)
             {
                 var wrappedList = instance is ICollection ? new List<object>(((ICollection)instance).Count) : new List<object>();
                 var enumerator = enumerable.GetEnumerator();


### PR DESCRIPTION
Two years ago ([5b83b3b](https://github.com/paulbartrum/jurassic/commit/5b83b3bd14791c061e797099e4bf3c0b79f46565)), instances of CLR collections began to be passed by value (not everywhere, this did not affect the instances, that passed directly). This innovation led to errors like this - [“TypeError: The method call is ambiguous between the following methods…”](https://github.com/paulbartrum/jurassic/issues/134).

To solve this problem, I suggest adding a property (`DisableClrCollectionsExposingByValue`) that allows to disable this feature.