### PR TITLE
Make a conversion to string without exception

### DIFF
--- a/Jurassic/Core/TypeConverter.cs
+++ b/Jurassic/Core/TypeConverter.cs
@@ -186,7 +186,7 @@ namespace Jurassic
                 throw new JavaScriptException(ErrorType.TypeError, "Cannot convert a Symbol value to a string.");
             if (value is ObjectInstance)
                 return ToString(ToPrimitive(value, PrimitiveTypeHint.String));
-            throw new ArgumentException(string.Format("Cannot convert object of type '{0}' to a string.", value.GetType()), nameof(value));
+            return value.ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
Hello, Paul!

In current version, when converting some types to a string, an exception is thrown. This PR changes this behavior.